### PR TITLE
BUG: sign of the eccentricity

### DIFF
--- a/ocbpy/ocb_correction.py
+++ b/ocbpy/ocb_correction.py
@@ -75,15 +75,15 @@ def elliptical(mlt, instrument='ampere', method='median'):
         raise ValueError("no elliptical correction for {:}".format(instrument))
 
     method = method.lower()
-    coeff = {"median": {"a": 4.01, "e": -0.55, "t": -0.92},
-             "gaussian": {"a": 4.41, "e": -0.51, "t": -0.95}}
+    coeff = {"median": {"a": 4.01, "e": 0.55, "t": -0.92},
+             "gaussian": {"a": 4.41, "e": 0.51, "t": -0.95}}
 
     if method not in coeff.keys():
         raise ValueError("unknown coefficient computation method")
 
     mlt_rad = hr2rad(mlt)
     r_corr = (coeff[method]["a"] * (1.0-coeff[method]["e"]**2) /
-              (1.0+coeff[method]["e"] * np.cos(mlt_rad-coeff[method]["t"])))
+              (1.0 + coeff[method]["e"]*np.cos(mlt_rad-coeff[method]["t"])))
 
     # Because this is a poleward correction, return the negative
     return -r_corr

--- a/ocbpy/tests/test_ocb_correction.py
+++ b/ocbpy/tests/test_ocb_correction.py
@@ -85,11 +85,11 @@ class TestOCBCorrection(unittest.TestCase):
                           'harmonic': ocb_cor.harmonic}
         self.mlt = np.arange(0.0, 24.0, 12.0)
         self.def_results = {'circular': np.zeros(shape=self.mlt.shape),
-                            'elliptical': np.array([-4.194630407939705,
-                                                    -2.0979393349197415]),
+                            'elliptical': np.array([-2.097939334919742,
+                                                    -4.194630407939707]),
                             'harmonic': np.array([-1.5821694271422921,
                                                   -3.4392638193624325])}
-        self.gaus_results = {'elliptical': -4.639223510917398,
+        self.gaus_results = {'elliptical': -2.51643691301747,
                              'harmonic': -2.293294645880221}
 
     def tearDown(self):


### PR DESCRIPTION
Addresses a bug where the eccentricity sign is negative in the AMPERE elliptical correction function in `ocb_correction.py`.  Physically, the eccentricity cannot be negative.  This bug was introduced by a typo in the original version of the elliptical equation (a negative sign in the denominator).

This addresses issue #58.