### PR TITLE
BUG: inverse haversine negative input

### DIFF
--- a/ocbpy/ocb_scaling.py
+++ b/ocbpy/ocb_scaling.py
@@ -865,7 +865,25 @@ def archav(hav):
     alpha : (float)
         Angle in radians
 
+    Notes
+    -----
+    The input must be positive.  However, any number with a magnitude below
+    10-16 will be rounded to zero.
+
     """
-    alpha = 2.0 * np.arcsin(np.sqrt(hav))
+
+    if np.isnan(hav):
+        # Propagate NaNs
+        alpha = np.nan
+    if hav >= 1.0e-16:
+        # The number is positive, calculate the angle
+        alpha = 2.0 * np.arcsin(np.sqrt(hav))
+    elif abs(hav) < 1.0e-16:
+        # The number is small enough that machine precision may have changed
+        # the sign, but it's a single-precission zero
+        alpha = 0
+    else:
+        # The input is negative
+        raise ValueError('Inverse Haversine requires a positive input')
 
     return alpha

--- a/ocbpy/ocb_scaling.py
+++ b/ocbpy/ocb_scaling.py
@@ -875,7 +875,7 @@ def archav(hav):
     if np.isnan(hav):
         # Propagate NaNs
         alpha = np.nan
-    if hav >= 1.0e-16:
+    elif hav >= 1.0e-16:
         # The number is positive, calculate the angle
         alpha = 2.0 * np.arcsin(np.sqrt(hav))
     elif abs(hav) < 1.0e-16:

--- a/ocbpy/tests/test_ocb_scaling.py
+++ b/ocbpy/tests/test_ocb_scaling.py
@@ -173,7 +173,7 @@ class TestOCBScalingMethods(unittest.TestCase):
     def test_inverse_haversine_nan(self):
         """ Test implimentation of the inverse haversine with NaN
         """
-        self.assertTrue(np.isnan(ocbpy.ocb_scaling.archav(np.nan))
+        self.assertTrue(np.isnan(ocbpy.ocb_scaling.archav(np.nan)))
 
     def test_calc_large_pole_angle(self):
         """ Test to see that the OCB polar angle calculation is performed

--- a/ocbpy/tests/test_ocb_scaling.py
+++ b/ocbpy/tests/test_ocb_scaling.py
@@ -163,7 +163,18 @@ class TestOCBScalingMethods(unittest.TestCase):
         """
         self.assertEqual(ocbpy.ocb_scaling.archav(0.0), 0.0)
         self.assertEqual(ocbpy.ocb_scaling.archav(1.0), np.pi)
-        
+
+    def test_inverse_haversine_small(self):
+        """ Test implimentation of the inverse haversine with very small numbers
+        """
+        self.assertEqual(ocbpy.ocb_scaling.archav(1.0e-17), 0.0)
+        self.assertEqual(ocbpy.ocb_scaling.archav(-1.0e-17), 0.0)
+
+    def test_inverse_haversine_nan(self):
+        """ Test implimentation of the inverse haversine with NaN
+        """
+        self.assertTrue(np.isnan(ocbpy.ocb_scaling.archav(np.nan))
+
     def test_calc_large_pole_angle(self):
         """ Test to see that the OCB polar angle calculation is performed
         properly when the angle is greater than 90 degrees
@@ -516,7 +527,7 @@ class TestOCBScalingMethods(unittest.TestCase):
         self.vdata.set_ocb(self.ocb, None)
         self.vdata.pole_angle = np.nan
         
-        with self.assertRaisesRegexp(ValueError, \
+        with self.assertRaisesRegexp(ValueError,
                             "vector angle in poles-vector triangle required"):
             self.vdata.scale_vector()
 
@@ -666,9 +677,16 @@ class TestOCBScalingMethods(unittest.TestCase):
         self.vdata.set_ocb(self.ocb, None)
         self.vdata.pole_angle = np.nan
         
-        with self.assertRaisesRegexp(ValueError, \
+        with self.assertRaisesRegexp(ValueError,
                             "vector angle in poles-vector triangle required"):
             self.vdata.define_quadrants()
+
+    def test_negative_angle_archav(self):
+        """Test inverse haversine failure with a negative angle"""
+
+        with self.assertRaisesRegexp(ValueError,
+                            "Inverse Haversine requires a positive input"):
+            ocbpy.ocb_scaling.archav(-1.0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This addresses the bug identified in #60, where machine precision can result in negative input for very small numbers into the `archav` function in `ocbpy.ocb_scaling`.  

To address this bug I added a check for NaN, and very small numbers.  Numbers with magnitudes below 1.0e-16 are now set to zero.  Larger negative numbers will raise a ValueError.