### PR TITLE
SSJ Auroral Boundary unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,36 @@
 language: python
-os:
-    - linux
-    - osx
 jobs:
     include:
-    - name: "Python 2.7 with SSJ_Auroral_Boundary"
+    - name: "Mac: Python 2.7 with SSJ_Auroral_Boundary"
+      os: osx
+      python: "2.7"
+      env: INSTALL_EXTRA=2 CDF_LIB=$HOME/lib
+    - name: "Linux: Python 2.7 with SSJ_Auroral_Boundary"
+      os: linux
       python: "2.7"
       env: INSTALL_EXTRA=2 CDF_LIB=$HOME/lib
     - name: "Python 3.5 basic install"
+      os: osx
+      python: "3.5"
+      env: INSTALL_EXTRA=0
+    - name: "Python 3.5 basic install"
+      os: linux
       python: "3.5"
       env: INSTALL_EXTRA=0
     - name: "Python 3.6 basic install"
+      os: osx
+      python: "3.6"
+      env: INSTALL_EXTRA=0
+    - name: "Python 3.6 basic install"
+      os: linux
       python: "3.6"
       env: INSTALL_EXTRA=0
     - name: "Python 3.7 basic install"
+      os: osx
+      python: "3.7"
+      env: INSTALL_EXTRA=0
+    - name: "Python 3.7 basic install"
+      os: linux
       python: "3.7"
       env: INSTALL_EXTRA=0
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ os:
     - linux
 jobs:
     include:
-        - name: "Python 2.7 with SSJ_Auroral_Boundary"
-	  python: "2.7"
-	  env: INSTALL_EXTRA=2 CDF_LIB=$HOME/lib
-	- name: "Python 3.5 basic install"
-	  python: "3.5"
-	  env: INSTALL_EXTRA=0
-	- name: "Python 3.6 basic install"
-	  python: "3.6"
-	  env: INSTALL_EXTRA=0
-	- name: "Python 3.7 basic install"
-	  python: "3.7"
-	  env: INSTALL_EXTRA=0
+    - name: "Python 2.7 with SSJ_Auroral_Boundary"
+      python: "2.7"
+      env: INSTALL_EXTRA=2 CDF_LIB=$HOME/lib
+    - name: "Python 3.5 basic install"
+      python: "3.5"
+      env: INSTALL_EXTRA=0
+    - name: "Python 3.6 basic install"
+      python: "3.6"
+      env: INSTALL_EXTRA=0
+    - name: "Python 3.7 basic install"
+      python: "3.7"
+      env: INSTALL_EXTRA=0
 addons:
     apt_packages:
         - gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,21 @@
 language: python
+os:
+    - linux
 jobs:
     include:
-    - name: "Mac: Python 2.7 with SSJ_Auroral_Boundary"
-      os: osx
+    - name: "Python 2.7 basic install"
       python: "2.7"
-      env: INSTALL_EXTRA=2 CDF_LIB=$HOME/lib
-    - name: "Linux: Python 2.7 with SSJ_Auroral_Boundary"
-      os: linux
+      env: INSTALL_EXTRA=0
+    - name: "Python 2.7 with SSJ_Auroral_Boundary"
       python: "2.7"
       env: INSTALL_EXTRA=2 CDF_LIB=$HOME/lib
     - name: "Python 3.5 basic install"
-      os: osx
-      python: "3.5"
-      env: INSTALL_EXTRA=0
-    - name: "Python 3.5 basic install"
-      os: linux
       python: "3.5"
       env: INSTALL_EXTRA=0
     - name: "Python 3.6 basic install"
-      os: osx
-      python: "3.6"
-      env: INSTALL_EXTRA=0
-    - name: "Python 3.6 basic install"
-      os: linux
       python: "3.6"
       env: INSTALL_EXTRA=0
     - name: "Python 3.7 basic install"
-      os: osx
-      python: "3.7"
-      env: INSTALL_EXTRA=0
-    - name: "Python 3.7 basic install"
-      os: linux
       python: "3.7"
       env: INSTALL_EXTRA=0
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 language: python
 os:
     - linux
-python:
-    - "2.7"
-    - "3.5"
-    - "3.6"
-    - "3.7"
-env:
-    - INSTALL_EXTRA=1
-    - INSTALL_EXTRA=2
+jobs:
+    include:
+        - name: "Python 2.7 with SSJ_Auroral_Boundary"
+	  python: "2.7"
+	  env: INSTALL_EXTRA=2 CDF_LIB=$HOME/lib
+	- name: "Python 3.5 basic install"
+	  python: "3.5"
+	  env: INSTALL_EXTRA=0
+	- name: "Python 3.6 basic install"
+	  python: "3.6"
+	  env: INSTALL_EXTRA=0
+	- name: "Python 3.7 basic install"
+	  python: "3.7"
+	  env: INSTALL_EXTRA=0
+addons:
+    apt_packages:
+        - gfortran
+        - gcc
 before_install:
     - pip install -r requirements.txt
     - bash requirements.extra $INSTALL_EXTRA

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 os:
     - linux
+    - osx
 jobs:
     include:
     - name: "Python 2.7 with SSJ_Auroral_Boundary"

--- a/requirements.extra
+++ b/requirements.extra
@@ -11,16 +11,40 @@ if [ $EXTRAS = 1 ]; then
     echo "Installed pysat"
 elif [ $EXTRAS = 2 ]; then
     # Install code for ssj_auroral_boundary
-    pip install spacepy, ephem, matplotlib, scipy, colorlog
+    # Start with requirements for spacepy
+    pip install scipy
+    pip install matplotlib
+    pip install h5py
+    pip install networkx
+    pip install ffnet
 
+    # Get CDF software and install it
+    wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/linux/cdf37_1-dist-cdf.tar.gz
+    tar xzf cdf37_1-dist-cdf.tar.gz
+    cd cdf37_1-dist
+    make OS=linux ENV=gnu all
+    make INSTALLDIR=$HOME install
+    # Running this command for definitions will break matplotlib
+    # . $HOME/bin/definitions.B
+    # Define environment variables in the .yml file
+    cd ..
+
+    # Go back to python
+    pip install ephem
+    pip install spacepy
+    pip install colorlog
+
+    # Finish with the ssj_auroral_boundary installation
     git clone https://github.com/lkilcommons/geospacepy-lite.git
     cd ./geospacepy-lite
     python setup.py install
+    cd ../.
 
     git clone https://github.com/lkilcommons/ssj_auroral_boundary.git
-    cd ../ssj_auroral_boundary
+    cd ./ssj_auroral_boundary
     python setup.py install
-
     cd ../.
-    echo "Installed SSJ_Auroral_Boundary"
+
+    echo "CDF library is installed here: " $CDF_LIB
+    echo "Finished extra installs for SSJ_Auroral_Boundary"
 fi


### PR DESCRIPTION
This fixes the installation code for the Travis CI testing of ssj_auroral_boundaries.  The Travis installation matrix was changed to only test this on Python 2.7, because the Python 3 branch of this code is still under development. (See issue: https://github.com/lkilcommons/ssj_auroral_boundary/issues/9)  

This partially addresses issue #56 