### PR TITLE
TST: Environment Updates -- numpy, pysat, pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ before_script:
       sleep 3;
     fi
 script:
-    - pytest -vs --cov=ocbpy/
+    - "coverage run --source=ocbpy setup.py test"
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
+services: xvfb
 addons:
     apt_packages:
         - gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ env:
 before_install:
     - pip install -r requirements.txt
     - bash requirements.extra $INSTALL_EXTRA
+    - pip install pytest
+    - pip install pytest-cov
 install:
     - "python setup.py install"
 script:
-    - "coverage run --source=ocbpy setup.py test"
+    - pytest -vs --cov=ocbpy/
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_install:
     - pip install pytest-cov
 install:
     - "python setup.py install"
+before_script:
+  # set up display screen
+  - export DISPLAY=:99.0
 script:
     - pytest -vs --cov=ocbpy/
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 os:
     - linux
+dist: bionic
 python:
     - "2.7"
     - "3.5"
@@ -19,8 +20,6 @@ before_install:
     # Force Travis CI to get a newer version of numpy
     - pip install numpy --upgrade
     - bash requirements.extra $INSTALL_EXTRA
-    - pip install pytest
-    - pip install pytest-cov
 install:
     - "python setup.py install"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
     - INSTALL_EXTRA=2 CDF_LIB=$HOME/lib
 before_install:
     - pip install -r requirements.txt
+    # Force Travis CI to get a newer version of numpy
+    - pip install numpy --upgrade
     - bash requirements.extra $INSTALL_EXTRA
     - pip install pytest
     - pip install pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ install:
 before_script:
   # set up display screen
   - export DISPLAY=:99.0
+  - if [[ $TRAVIS_PYTHON_VERSION < "3.0" ]]; then
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+    fi
 script:
     - pytest -vs --cov=ocbpy/
 after_success: coveralls

--- a/ocbpy/instruments/__init__.py
+++ b/ocbpy/instruments/__init__.py
@@ -16,7 +16,7 @@ from __future__ import (absolute_import)
 import logging
 
 from . import (general)
-from .general import (test_file)
+from .general import (check_file)
 from . import (supermag)
 from . import (vort)
 

--- a/ocbpy/instruments/general.py
+++ b/ocbpy/instruments/general.py
@@ -3,7 +3,7 @@
 
 Functions
 -------------------------------------------------------------------------------
-test_file(filename)
+check_file(filename)
     Test to see whether file exists and is small enough to load
 load_ascii_data(filename, hlines, kwargs)
     Load time-sorted ascii data file
@@ -18,7 +18,7 @@ from os import path
 import ocbpy
 import ocbpy.ocb_time as ocbt
 
-def test_file(filename):
+def check_file(filename):
     """Test to ensure the file is small enough to read in.  Python can only
     allocate 2GB of data without crashing
 
@@ -37,7 +37,7 @@ def test_file(filename):
     if not path.isfile(filename):
         ocbpy.logger.warning("name provided is not a file")
         return False
-    
+
     fsize = path.getsize(filename)
 
     if(fsize > 2.0e9):
@@ -53,7 +53,7 @@ def test_file(filename):
 def load_ascii_data(filename, hlines, gft_kwargs=dict(), hsplit=None,
                     datetime_cols=list(), datetime_fmt=None, int_cols=list(),
                     str_cols=list(), max_str_length=50, header=list()):
-    """ Load an ascii data file into a dict of numpy array. 
+    """ Load an ascii data file into a dict of numpy array.
 
     Parameters
     ------------
@@ -103,7 +103,7 @@ def load_ascii_data(filename, hlines, gft_kwargs=dict(), hsplit=None,
     #-----------------------------------------------------------------------
     # Test to ensure the file is small enough to read in.  Python can only
     # allocate 2GB of data.  If you load something larger, python will crash
-    if not test_file(filename):
+    if not check_file(filename):
         return header, dict()
 
     #--------------------------------------------------
@@ -162,7 +162,7 @@ def load_ascii_data(filename, hlines, gft_kwargs=dict(), hsplit=None,
 
     for icol in str_cols:
         ldtype[icol] = '|U{:d}'.format(max_str_length)
-    
+
     #---------------------------------------------------------------------
     # Build and add the datetime objects to the output dictionary
     dt_keys = ['datetime', 'DATETIME', 'DT', 'dt']

--- a/ocbpy/instruments/supermag.py
+++ b/ocbpy/instruments/supermag.py
@@ -71,7 +71,7 @@ def supermag2ascii_ocb(smagfile, outfile, hemisphere=0, ocb=None,
 
     """
 
-    if not ocbpy.instruments.test_file(smagfile):
+    if not ocbpy.instruments.check_file(smagfile):
         raise IOError("SuperMAG file cannot be opened [{:s}]".format(smagfile))
 
     if not isinstance(outfile, str):
@@ -138,11 +138,11 @@ def supermag2ascii_ocb(smagfile, outfile, hemisphere=0, ocb=None,
         outline = "".join([outline, "MLAT MLT BMAG BN BE BZ OCB_MLAT OCB_MLT ",
                            "OCB_BMAG OCB_BN OCB_BE OCB_BZ\n"])
         fout.write(outline)
-    
+
         # Initialise the ocb and SuperMAG indices
         imag = 0
         nmag = mdata['DATETIME'].shape[0]
-    
+
         # Cycle through the data, matching SuperMAG and OCB records
         while imag < nmag and ocb.rec_ind < ocb.records:
             imag = ocbpy.match_data_ocb(ocb, mdata['DATETIME'], idat=imag,
@@ -192,7 +192,7 @@ def supermag2ascii_ocb(smagfile, outfile, hemisphere=0, ocb=None,
 
                 # Move to next line
                 imag += 1
-        
+
     return
 
 #---------------------------------------------------------------------------
@@ -212,9 +212,9 @@ def load_supermag_ascii_data(filename):
         The dict keys are specified by the header data line, the data
         for each key are stored in the numpy array
     """
-    from ocbpy.instruments import test_file
+    from ocbpy.instruments import check_file
     import datetime as dt
-    
+
     fill_val = 999999
     header = list()
     ind = {"SMU": fill_val, "SML": fill_val}
@@ -223,10 +223,10 @@ def load_supermag_ascii_data(filename):
            "SML": list(), "SMU": list(), "STID": list(), "BN": list(),
            "BE": list(), "BZ": list(), "MLT": list(), "MLAT": list(),
            "DEC": list(), "SZA": list()}
-    
-    if not test_file(filename):
+
+    if not check_file(filename):
         return header, dict()
-    
+
     #----------------------------------------------
     # Open the datafile and read the data
     with open(filename, "r") as f:
@@ -292,7 +292,7 @@ def load_supermag_ascii_data(filename):
 
             if k in ['BE', 'BN', 'DEC', 'SZA', 'MLT', 'BZ']:
                 out[k][out[k] == fill_val] = np.nan
-    
+
     return header, out
 
 # End load_supermag_ascii_data

--- a/ocbpy/instruments/vort.py
+++ b/ocbpy/instruments/vort.py
@@ -73,7 +73,7 @@ def vort2ascii_ocb(vortfile, outfile, hemisphere=0, ocb=None, ocbfile='default',
 
     """
 
-    if not ocbpy.instruments.test_file(vortfile):
+    if not ocbpy.instruments.check_file(vortfile):
         raise IOError("vorticity file cannot be opened [{:s}]".format(vortfile))
 
     if not isinstance(outfile, str):
@@ -82,7 +82,7 @@ def vort2ascii_ocb(vortfile, outfile, hemisphere=0, ocb=None, ocbfile='default',
     # Read the vorticity data
     vdata = load_vorticity_ascii_data(vortfile, save_all=save_all)
     need_keys = ["VORTICITY", "CENTRE_MLAT", "DATETIME", "MLT"]
-    
+
     if vdata is None or not all([kk in vdata.keys() for kk in need_keys]):
         estr = "unable to load necessary data from [{:s}]".format(vortfile)
         raise ValueError(estr)
@@ -182,7 +182,7 @@ def vort2ascii_ocb(vortfile, outfile, hemisphere=0, ocb=None, ocbfile='default',
 
                 # Move to next line
                 ivort += 1
-        
+
     return
 
 def load_vorticity_ascii_data(vortfile, save_all=False):
@@ -203,7 +203,7 @@ def load_vorticity_ascii_data(vortfile, save_all=False):
 
     """
 
-    if not ocbpy.instruments.test_file(vortfile):
+    if not ocbpy.instruments.check_file(vortfile):
         return None
 
     # Open the data file

--- a/ocbpy/ocboundary.py
+++ b/ocbpy/ocboundary.py
@@ -84,7 +84,7 @@ class OCBoundary(object):
         Numpy array of floats that hold the remaining values in input file
 
     Methods
-    ---------- 
+    ----------
     inst_defaults()
         Get the information needed to load an OCB file using instrument
         specific formatting, and update the boundary latitude for a given
@@ -136,7 +136,7 @@ class OCBoundary(object):
             Minimum acceptable figure of merit for data (default=0)
         rfunc : (np.ndarray, function, or NoneType)
             OCB radius correction function, if None will use instrument default.
-            Function must have AACGM MLT as argument input. (default=None) 
+            Function must have AACGM MLT as argument input. (default=None)
         rfunc_kwargs : (np.ndarray, dict, or NoneType)
             OCB radius correction function keyword arguments. (default={})
 
@@ -165,7 +165,7 @@ class OCBoundary(object):
 
             # If a filename is available, make sure it is good
             if self.filename is not None:
-                if not ocbpy.instruments.test_file(self.filename):
+                if not ocbpy.instruments.check_file(self.filename):
                     # If the filename is bad, return an uninitialized object
                     estr = "cannot open OCB file [{:s}]".format(self.filename)
                     ocbpy.logger.warning(estr)
@@ -207,7 +207,7 @@ class OCBoundary(object):
 
     def __repr__(self):
         """ Provide readable representation of the OCBoundary object """
-    
+
         if self.filename is None:
             out = "No Open-Closed Boundary file specified\n"
         else:
@@ -306,7 +306,7 @@ class OCBoundary(object):
         Parameters
         -----------
         ocb_cols : (str)
-            String specifying format of OCB file.  All but the first two 
+            String specifying format of OCB file.  All but the first two
             columns must be included in the string, additional data values will
             be ignored.  If 'year soy' aren't used, expects
             'date time' in 'YYYY-MM-DD HH:MM:SS' format.
@@ -324,7 +324,7 @@ class OCBoundary(object):
             (default=None)
 
         """
-        
+
         cols = ocb_cols.split()
         dflag = -1
         ldtype = [(k,float) if k != "num_sectors" else (k,int) for k in cols]
@@ -341,7 +341,7 @@ class OCBoundary(object):
             estr = "missing time columns in [{:s}]".format(ocb_cols)
             ocbpy.logger.error(estr)
             return
-        
+
         # Read the OCB data
         odata = np.rec.array(np.genfromtxt(self.filename, skip_header=hlines,
                                            dtype=ldtype))
@@ -363,7 +363,7 @@ class OCBoundary(object):
             soy = odata.soy[i] if dflag == 0 else None
             date = None if dflag == 0 else odata.date[i]
             tod = None if dflag == 0 else odata.time[i]
-                
+
             dtime = convert_time(year=year, soy=soy, date=date, tod=tod,
                                  datetime_fmt=datetime_fmt)
 
@@ -463,7 +463,7 @@ class OCBoundary(object):
 
         # Incriment forward from previous boundary
         self.rec_ind += 1
-        
+
         while self.rec_ind < self.records:
             # Evaluate the current boundary for quality, using optional
             # parameters
@@ -514,7 +514,7 @@ class OCBoundary(object):
             Magnetic local time relative to OCB (hours)
         r_corr : (float)
             Radius correction to OCB (degrees)
- 
+
         Comments
         ---------
         Approximation - Conversion assumes a planar surface
@@ -602,13 +602,13 @@ class OCBoundary(object):
             latitude (degrees)
         lt : (float)
             local time (hours)
- 
+
         Comments
         ---------
         Approximation - Conversion assumes a planar surface
 
         """
-        
+
         if self.rec_ind < 0 or self.rec_ind >= self.records:
             return np.nan, np.nan
 
@@ -697,7 +697,7 @@ class OCBoundary(object):
         aacgm_lon = np.array(aacgm_lon)
         aacgm_lon[aacgm_lon < 0.0] += 360.0
         aacgm_lon[aacgm_lon >= 360.0] -= 360.0
-            
+
         if not hasattr(self, 'aacgm_boundary_lon'):
             self.aacgm_boundary_lon = [None for i in range(self.records)]
 
@@ -750,7 +750,7 @@ class OCBoundary(object):
         return
 
     def _set_default_rfunc(self):
-        """Set the default instrument OCB boundary function 
+        """Set the default instrument OCB boundary function
 
         Notes
         -----
@@ -806,7 +806,7 @@ def retrieve_all_good_indices(ocb):
     # Return the good indices
     return good_ind
 
-    
+
 def match_data_ocb(ocb, dat_dtime, idat=0, max_tol=600, min_sectors=7,
                    rcent_dev=8.0, max_r=23.0, min_r=10.0):
     """Matches data records with OCB records, locating the closest values
@@ -932,5 +932,5 @@ def match_data_ocb(ocb, dat_dtime, idat=0, max_tol=600, min_sectors=7,
         estr = "".join(["no OCB data available within [{:d} s]".format(max_tol),
                         " of first measurement [{:}]".format(dat_dtime[idat])])
         ocbpy.logger.info(estr)
-    
+
     return idat

--- a/ocbpy/tests/test_general.py
+++ b/ocbpy/tests/test_general.py
@@ -42,14 +42,14 @@ class TestGeneralFileTestMethods(unittest.TestCase):
 
     def test_file_test_success(self):
         """ Test the success condition for one of the test_data files"""
-        self.rstat = ocb_igen.test_file(self.test_file)
+        self.rstat = ocb_igen.check_file(self.test_file)
         self.assertTrue(self.rstat)
-        
+
     def test_file_test_not_file(self):
         """ Test the general file testing routine with a bad filename """
         self.lwarn = u"name provided is not a file"
-        
-        self.rstat = ocb_igen.test_file("/")
+
+        self.rstat = ocb_igen.check_file("/")
         self.lout = self.log_capture.getvalue()
 
         self.assertTrue(self.lout.find(self.lwarn) >= 0)
@@ -58,10 +58,10 @@ class TestGeneralFileTestMethods(unittest.TestCase):
     def test_file_test_empty_file(self):
         """ Test the general file testing routine with a bad filename """
         self.lwarn = u'empty file'
-        
+
         # Create an empty file and read it in
         open(self.temp_output, 'a').close()
-        self.rstat = ocb_igen.test_file(self.temp_output)
+        self.rstat = ocb_igen.check_file(self.temp_output)
         self.lout = self.log_capture.getvalue()
 
         self.assertTrue(self.lout.find(self.lwarn) >= 0)
@@ -75,7 +75,7 @@ class TestGeneralFileTestMethods(unittest.TestCase):
         with open(self.temp_output, 'wb') as fout:
             fout.truncate(2024 * 1024 * 1024)
 
-        self.rstat = ocb_igen.test_file(self.temp_output)
+        self.rstat = ocb_igen.check_file(self.temp_output)
         self.lout = self.log_capture.getvalue()
 
         self.assertTrue(self.lout.find(self.lwarn) >= 0)
@@ -356,4 +356,3 @@ class TestGeneralLoadMethods(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/ocbpy/tests/test_supermag.py
+++ b/ocbpy/tests/test_supermag.py
@@ -17,7 +17,7 @@ if platform.system().lower() != "windows":
 
 import ocbpy
 import ocbpy.instruments.supermag as ocb_ismag
-from ocbpy.instruments.general import test_file
+from ocbpy.instruments.general import check_file
 
 class TestSuperMAG2AsciiMethods(unittest.TestCase):
 
@@ -25,7 +25,7 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
         """ Initialize the OCBoundary object using the test file, as well as
         the VectorData object
         """
-        
+
         self.ocb_dir = os.path.dirname(ocbpy.__file__)
         self.test_ocb = os.path.join(self.ocb_dir, "tests", "test_data",
                                      "test_north_circle")
@@ -277,26 +277,26 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
                 with self.assertRaisesRegex(IOError, val[0]):
                     ocb_ismag.supermag2ascii_ocb(*val[1], ocbfile=self.test_ocb)
 
-    
+
     def test_supermag2ascii_ocb_bad_ocb(self):
         """ Test the SuperMAG conversion with a bad ocb file """
         ocb_ismag.supermag2ascii_ocb(self.test_file, "fake_out",
                                      ocbfile="fake_ocb", hemisphere=1)
 
         # Compare created file to stored test file
-        self.assertFalse(test_file("fake_out"))
+        self.assertFalse(check_file("fake_out"))
 
 
 class TestSuperMAGLoadMethods(unittest.TestCase):
     def setUp(self):
         """ Initialize the filenames and data needed to test SuperMAG loading
         """
-        
+
         self.ocb_dir = os.path.dirname(ocbpy.__file__)
         self.test_file = os.path.join(self.ocb_dir, "tests", "test_data",
                                       "test_smag")
         self.test_vals = {'BE': -6.0, 'BN': -23.6, 'BZ': -25.2, 'DAY': 5,
-                          'DEC': 17.13, 'HOUR': 13, 'MIN': 40, 'MLAT': 77.22, 
+                          'DEC': 17.13, 'HOUR': 13, 'MIN': 40, 'MLAT': 77.22,
                           'DATETIME': dt.datetime(2000,5,5,13,40,30),
                           'MLT': 15.86, 'MONTH': 5, 'NST': 2, 'SEC': 30,
                           'SML': -195, 'SMU': 124, 'STID': "THL", 'SZA': 76.97,

--- a/ocbpy/tests/test_vort.py
+++ b/ocbpy/tests/test_vort.py
@@ -26,7 +26,7 @@ class TestVortLogWarnings(unittest.TestCase):
         """ Initialize the OCBoundary object using the test file, as well as
         the VectorData object
         """
-        
+
         self.ocb_dir = os.path.dirname(ocbpy.__file__)
         self.test_file = os.path.join(self.ocb_dir, "tests", "test_data",
                                       "test_vort")
@@ -146,7 +146,7 @@ class TestVort2AsciiMethods(unittest.TestCase):
         """ Initialize the OCBoundary object using the test file, as well as
         the VectorData object
         """
-        
+
         self.ocb_dir = os.path.dirname(ocbpy.__file__)
         self.test_ocb = os.path.join(self.ocb_dir, "tests", "test_data",
                                      "test_north_circle")
@@ -411,7 +411,7 @@ class TestVort2AsciiMethods(unittest.TestCase):
             ocb_ivort.vort2ascii_ocb(self.test_empty, "fake_out",
                                      ocbfile=self.test_ocb)
 
-            
+
     def test_vort2ascii_ocb_no_ocb(self):
         """ Test the conversion of vorticity data from AACGM coordinates into
         OCB coordinates
@@ -420,7 +420,7 @@ class TestVort2AsciiMethods(unittest.TestCase):
                                  hemisphere=1)
 
         # Compare created file to stored test file
-        self.assertFalse(ocbpy.instruments.general.test_file("fake_out"))
+        self.assertFalse(ocbpy.instruments.general.check_file("fake_out"))
 
     def test_vort2ascii_ocb_output_failure(self):
         """ Test failure when bad filename is provided
@@ -443,7 +443,7 @@ class TestVortLoadMethods(unittest.TestCase):
         """ Initialize the OCBoundary object using the test file, as well as
         the VectorData object
         """
-        
+
         self.ocb_dir = os.path.dirname(ocbpy.__file__)
         self.test_ocb = os.path.join(self.ocb_dir, "tests", "test_data",
                                      "test_north_circle")

--- a/requirements.extra
+++ b/requirements.extra
@@ -9,6 +9,7 @@ if [ $EXTRAS = 1 ]; then
     pip install "pandas>=0.23, <0.25"
     pip install "xarray<0.15"
     pip install "kiwisolver<1.2"
+    pip install "netCDF4<1.5.3"
     pip install madrigalWeb
     pip install PyForecastTools
     pip install pysatCDF >/dev/null
@@ -53,7 +54,7 @@ elif [ $EXTRAS = 2 ]; then
     python setup.py install
 
     cd ../.
-    
+
     printf "import geospacepy\nprint(geospacepy.__file__)\n" | python
     printf "import ssj_auroral_boundary\nprint(ssj_auroral_boundary.__file__)\n" | python
     echo "CDF library is installed here: " $CDF_LIB

--- a/requirements.extra
+++ b/requirements.extra
@@ -17,7 +17,7 @@ if [ $EXTRAS = 1 ]; then
     cd ..
     git clone http://www.github.com/pysat/pysat
     cd pysat
-    git checckout develop
+    git checkout develop
     python setup.py install
     cd ../ocbpy
     # Make the pysat data directory

--- a/requirements.extra
+++ b/requirements.extra
@@ -9,7 +9,6 @@ if [ $EXTRAS = 1 ]; then
     pip install "pandas>=0.23, <0.25"
     pip install "xarray<0.15"
     pip install "kiwisolver<1.2"
-    pip install "netCDF4<1.5.3"
     pip install madrigalWeb
     pip install PyForecastTools
     pip install pysatCDF >/dev/null

--- a/requirements.extra
+++ b/requirements.extra
@@ -14,7 +14,12 @@ if [ $EXTRAS = 1 ]; then
     pip install PyForecastTools
     pip install pysatCDF >/dev/null
     # Install pysat
-    pip install "pysat>=2.0.0"
+    cd ..
+    git clone http://www.github.com/pysat/pysat
+    cd pysat
+    git checckout develop
+    python setup.py install
+    cd ../ocbpy
     # Make the pysat data directory
     printf "import os\nimport pysat\npdir=os.path.join(os.path.split(pysat.__file__)[0], 'pysatData')\nos.mkdir(pdir)\npysat.utils.set_data_dir(pdir)" | python
     echo "Finished extra installs for pysat"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+numpy
 aacgmv2
 coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-numpy<=1.15.4
 aacgmv2
 coveralls


### PR DESCRIPTION
Addresses #50 and #56.

Summary
- Removes cap on numpy versions
- Installs pysat from github, not pip
- Uses pytest to manage unit tests
- Adds xvfb services to Travis to enable existing plot tests
- Renames `test_file` in `ocbpy.instruments.general` as `check_file`

Rationale
- Looking through the linked issue in #50, the numpy issues above seem result from however unittest collects the tests.  pytest is versatile enough that it can manage the unit tests without having to rewrite them, and I don't see these issues with newer versions of numpy.  
- The pysat_testing instrument is not included in the available pip versions.  This should be updated for pysat 2.2.  Using github develop branch as a test, but this could be the master branch as well.  Could be returned to pip install once the new version is out.
- Pytest will gather any method that begins with the word "test" as a test to be run.  The `test_file` method is renamed to avoid this.  It also improves clarity as the unit tests include a `test_file` variable.
- In the EXTRA=2 tests, some of these tests use matplotlib.  Adding services to set up a display in the python 2.7 tests, as documented here: https://stackoverflow.com/questions/35403127/testing-matplotlib-based-plots-in-travis-ci  NOTE: the python 3.x tests do not need these lines.

Python 3.5 is running into issues with netCDF4.  I recommend dropping 3.5 support, as many packages are dropping support for this and it will make things harder down the line.  netCDF4 has officially dropped support for it, though there still are wheels for this on pypi.