### PR TITLE
Python 2.7 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ env:
         - INSTALL_EXTRA=1
         - INSTALL_EXTRA=2
 python:
-    - 2.7
-    - 3.5
-    - 3.6
-    - 3.7
-    - 3.8
+    - "3.6"
+    - "3.7"
+    - "3.8"
+    - "3.9"
 
 jobs:
    allow_failures:

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,13 @@ Changelog
 
 Summary of all changes made since the first stable release
 
+0.2.X (XX-XX-2021)
+------------------
+* DOC: Improved the PEP8 compliance in the documentation examples
+* BUG: Fixed header initialization error general instrument loading routine
+* MAINT: Removed support for Python 2.7 and 3.5
+
+
 0.2.1 (11-24-2020)
 ------------------
 * DOC: Updated examples in README

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ These routines may be used as a guide to write routines for other datasets.
 
 # Python versions
 
-This module has been tested on python version 2.7, 3.5 - 3.8.  Support for 2.7
-will be dropped in 2020.
+This module currently supports Python version 3.6 - 3.9.
 
 # Dependencies
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,6 @@ environment:
     WITH_COMPILER: 'cmd /E:ON /V:ON /C .\ci\appveyor-with-compiler.cmd'
     BASH_CMD: "bash requirements.extra 0"
   matrix:
-    - job_name: P27-x32 basic
-      PYTHON: "C:\\Python27"
-      NUMPY: "numpy==1.15.4"
-    - job_name: P35-x32 basic
-      PYTHON: "C:\\Python35"
-      NUMPY: "numpy==1.15.4"
     - job_name: P36-x32 basic
       PYTHON: "C:\\Python36"
       NUMPY: "numpy>=1.19.0"
@@ -38,12 +32,9 @@ environment:
     - job_name: P38-x32 basic
       PYTHON: "C:\\Python38"
       NUMPY: "numpy>=1.19.0"
-    - job_name: P27-x64 basic
-      PYTHON: "C:\\Python27-x64"
-      NUMPY: "numpy==1.15.4"
-    - job_name: P35-x64 basic
-      PYTHON: "C:\\Python35-x64"
-      NUMPY: "numpy==1.15.4"
+    - job_name: P39-x32 basic
+      PYTHON: "C:\\Python39"
+      NUMPY: "numpy>=1.19.0"
     - job_name: P36-x64 basic
       PYTHON: "C:\\Python36-x64"
       NUMPY: "numpy>=1.19.0"
@@ -52,6 +43,9 @@ environment:
       NUMPY: "numpy>=1.19.0"
     - job_name: P38-x64 basic
       PYTHON: "C:\\Python38-x64"
+      NUMPY: "numpy>=1.19.0"
+    - job_name: P39-x64 basic
+      PYTHON: "C:\\Python39-x64"
       NUMPY: "numpy>=1.19.0"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
-#---------------------------------#
-#      general configuration      #
-#---------------------------------#
+# -----------------------------------------------------------------------------
+# General configuration
+# -----------------------------------------------------------------------------
 
 # version format
 version: '{branch}-{build}'
@@ -11,16 +11,20 @@ skip_tags: true
 # Maximum number of concurrent jobs for the project
 max_jobs: 2
 
-#---------------------------------#
-#    environment configuration    #
-#---------------------------------#
+# -----------------------------------------------------------------------------
+# Environment configuration
+#
+# Added image to ensure all Python versions are available
+# -----------------------------------------------------------------------------
 
 init:
   - ps: echo $env:TESTENV
 
+image:
+- Visual Studio 2019
 environment:
   global:
-    WITH_COMPILER: 'cmd /E:ON /V:ON /C .\ci\appveyor-with-compiler.cmd'
+    WITH_COMPILER: 'cmd /E:ON /V:ON /C'
     BASH_CMD: "bash requirements.extra 0"
   matrix:
     - job_name: P36-x32 basic

--- a/docs/examples/ex_general.rst
+++ b/docs/examples/ex_general.rst
@@ -1,6 +1,6 @@
 
 Load a general data file (DMSP SSIES)
----------------------------------------------
+-------------------------------------
 DMSP SSIES provides commonly used polar data, which can be accessed from
 `Madrigal <http://cedar.openmadrigal.org/>`_, which also has a Python API called
 `madrigalWeb <https://pypi.org/project/madrigalWeb/>`_.  To run this example,
@@ -42,10 +42,13 @@ OCB coordinates and find out which data have a good quality flag.
    ram_key = 'ION_V_SAT_FOR'
    rpa_key = 'RPA_FLAG_UT'
    idm_key = 'IDM_FLAG_UT'
-   dmsp_data['OCB_MLT'] = np.full(shape=dmsp_data[ram_key].shape, fill_value=np.nan)
-   dmsp_data['OCB_LAT'] = np.full(shape=dmsp_data[ram_key].shape, fill_value=np.nan)
+   dmsp_data['OCB_MLT'] = np.full(shape=dmsp_data[ram_key].shape,
+                                  fill_value=np.nan)
+   dmsp_data['OCB_LAT'] = np.full(shape=dmsp_data[ram_key].shape,
+                                  fill_value=np.nan)
    igood = np.where((dmsp_data[rpa_key] < 3) & (dmsp_data[idm_key] < 3))
-   print(len(igood[0]), dmsp_data[ram_key][igood].max(), dmsp_data[ram_key][igood].min())
+   print(len(igood[0]), dmsp_data[ram_key][igood].max(),
+         dmsp_data[ram_key][igood].min())
 
    7623 978.0 -2159.0
 
@@ -73,9 +76,12 @@ This is the starting point for cycling through the records.
 
    
    while idmsp < ndmsp and ocb.rec_ind < ocb.records:
-       idmsp = ocbpy.match_data_ocb(ocb, dmsp_data['datetime'][igood], idat=idmsp, max_tol=600)
+       idmsp = ocbpy.match_data_ocb(ocb, dmsp_data['datetime'][igood],
+                                    idat=idmsp, max_tol=600)
        if idmsp < ndmsp and ocb.rec_ind < ocb.records:
-           nlat, nmlt, r_corr = ocb.normal_coord(dmsp_data['MLAT'][igood[0][idmsp]], dmsp_data['MLT'][igood[0][idmsp]])
+           nlat, nmlt, r_corr = ocb.normal_coord(
+	       dmsp_data['MLAT'][igood[0][idmsp]],
+	       dmsp_data['MLT'][igood[0][idmsp]])
            dmsp_data['OCB_LAT'][igood[0][idmsp]] = nlat
            dmsp_data['OCB_MLT'][igood[0][idmsp]] = nmlt
            idmsp += 1
@@ -96,14 +102,16 @@ coordinates rather than magnetic coordinates, adding an additional
 
    
    fig = plt.figure()
-   fig.suptitle("DMSP F15 in OCB Coordinates on {:}".format(dmsp_data['datetime'][igood][0].strftime('%d %B %Y')))
+   fig.suptitle("DMSP F15 in OCB Coordinates on {:}".format(
+       dmsp_data['datetime'][igood][0].strftime('%d %B %Y')))
    ax = fig.add_subplot(111, projection="polar")
    ax.set_theta_zero_location("S")
    ax.xaxis.set_ticks([0, 0.5*np.pi, np.pi, 1.5*np.pi])
    ax.xaxis.set_ticklabels(["00:00", "06:00", "12:00 MLT", "18:00"])
    ax.set_rlim(0,40)
    ax.set_rticks([10,20,30,40])
-   ax.yaxis.set_ticklabels(["80$^\circ$", "70$^\circ$", "60$^\circ$", "50$^\circ$"])
+   ax.yaxis.set_ticklabels(["80$^\circ$", "70$^\circ$", "60$^\circ$",
+                            "50$^\circ$"])
 
    lon = np.arange(0.0, 2.0 * np.pi + 0.1, 0.1)
    lat = np.ones(shape=lon.shape) * (90.0 - ocb.boundary_lat)
@@ -112,12 +120,15 @@ coordinates rather than magnetic coordinates, adding an additional
    dmsp_lon = dmsp_data['OCB_MLT'][igood] * np.pi / 12.0
    dmsp_lat = 90.0 - dmsp_data['OCB_LAT'][igood]
    dmsp_time = mpl.dates.date2num(dmsp_data['datetime'][igood])
-   ax.scatter(dmsp_lon, dmsp_lat, c=dmsp_time, cmap=mpl.cm.get_cmap("viridis"), marker="o", s=10)
+   ax.scatter(dmsp_lon, dmsp_lat, c=dmsp_time, cmap=mpl.cm.get_cmap("viridis"),
+              marker="o", s=10)
    ax.text(10 * np.pi / 12.0, 41, "Start of satellite track")
 
    tticks = np.linspace(dmsp_time.min(), dmsp_time.max(), 6, endpoint=True)
-   dticks = ["{:s}".format(mpl.dates.num2date(tval).strftime("%H:%M")) for tval in tticks]
-   cb = fig.colorbar(ax.collections[0], ax=ax, ticks=tticks, orientation='horizontal')
+   dticks = ["{:s}".format(mpl.dates.num2date(tval).strftime("%H:%M"))
+             for tval in tticks]
+   cb = fig.colorbar(ax.collections[0], ax=ax, ticks=tticks,
+                     orientation='horizontal')
    cb.ax.set_xticklabels(dticks)
    cb.set_label('Universal Time (HH:MM)')
    ax.legend(fontsize='medium', bbox_to_anchor=(0.0,1.0))

--- a/docs/examples/ex_rec.rst
+++ b/docs/examples/ex_rec.rst
@@ -14,7 +14,8 @@ To get the OCB record closest to a specified time, use **ocbpy.match_data_ocb**
 
    
    first_good_time = ocb.dtime[ocb.rec_ind]
-   test_times = [first_good_time + dt.timedelta(minutes=5*(i+1)) for i in range(5)]
+   test_times = [first_good_time + dt.timedelta(minutes=5 * (i + 1))
+                 for i in range(5)]
    itest = ocbpy.match_data_ocb(ocb, test_times, idat=0)
    print(itest, ocb.rec_ind, test_times[itest], ocb.dtime[ocb.rec_ind])
   

--- a/ocbpy/__init__.py
+++ b/ocbpy/__init__.py
@@ -28,17 +28,16 @@ ocb_correction Boundary correction utilities
 
 """
 
-from __future__ import absolute_import, unicode_literals
-
+# Define a logger object to allow easier log handling
 import logging
 
+logging.raiseExceptions = False
+logger = logging.getLogger('ocbpy_logger')
+
+# Import the package modules and top-level classes
 from ocbpy import ocboundary, ocb_scaling, ocb_time, ocb_correction
 from ocbpy.ocboundary import OCBoundary, match_data_ocb
 from ocbpy import instruments, boundaries
 
 # Define the global variables
 __version__ = str('0.2.1')
-
-# Define a logger object to allow easier log handling
-logging.raiseExceptions = False
-logger = logging.getLogger('ocbpy_logger')

--- a/ocbpy/boundaries/__init__.py
+++ b/ocbpy/boundaries/__init__.py
@@ -10,12 +10,10 @@ files          Boundary file utilities
 dmsp_ssj_files DMSP SSJ boundary file utilities
 
 """
-from __future__ import absolute_import
-import logging
-
+from ocbpy import logger
 from ocbpy.boundaries import files
 
 try:
     from ocbpy.boundaries import dmsp_ssj_files
 except ImportError as ierr:
-    logging.warning(ierr)
+    logger.warning(ierr)

--- a/ocbpy/boundaries/dmsp_ssj_files.py
+++ b/ocbpy/boundaries/dmsp_ssj_files.py
@@ -31,18 +31,11 @@ Kilcommons, L.M., et al. (2017), A new DMSP magnetometer and auroral boundary
 
 """
 
-from __future__ import absolute_import, unicode_literals
-
 import datetime as dt
 import numpy as np
 import os
-import sys
 
 import ocbpy
-
-if sys.version_info.major == 2:
-    import warnings
-    warnings.simplefilter('default')
 
 # AGB: The TypeError exception below is necessary due to a bug in
 # ssj_auroral_boundary that was introduced by a change in matplotlib

--- a/ocbpy/boundaries/files.py
+++ b/ocbpy/boundaries/files.py
@@ -29,7 +29,6 @@ Milan, S. E., et al. (2015), Principal component analysis of
   10,415–10,424, doi:10.1002/2015JA021680.
 
 """
-from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
 import itertools

--- a/ocbpy/instruments/__init__.py
+++ b/ocbpy/instruments/__init__.py
@@ -12,9 +12,7 @@ general     General file loading and testing routines
 pysat       General pysat Instrument loading routines: https://github.com/pysat
 
 """
-from __future__ import (absolute_import)
-import logging
-
+from ocbpy import logger
 from ocbpy.instruments import general
 from ocbpy.instruments.general import test_file
 from ocbpy.instruments import supermag
@@ -23,4 +21,4 @@ from ocbpy.instruments import vort
 try:
     from ocbpy.instruments import pysat_instruments
 except ImportError as ierr:
-    logging.warning(ierr)
+    logger.warning(ierr)

--- a/ocbpy/instruments/general.py
+++ b/ocbpy/instruments/general.py
@@ -53,8 +53,8 @@ def test_file(filename):
 
 
 def load_ascii_data(filename, hlines, gft_kwargs=dict(), hsplit=None,
-                    datetime_cols=list(), datetime_fmt=None, int_cols=list(),
-                    str_cols=list(), max_str_length=50, header=list()):
+                    datetime_cols=None, datetime_fmt=None, int_cols=None,
+                    str_cols=None, max_str_length=50, header=None):
     """ Load an ascii data file into a dict of numpy array
 
     Parameters
@@ -69,24 +69,26 @@ def load_ascii_data(filename, hlines, gft_kwargs=dict(), hsplit=None,
     hsplit : (str, NoneType)
         character seperating data labels in header.  None splits on all
         whitespace characters. (default=None)
-    datetime_cols : (list of ints)
+    datetime_cols : (list, NoneType)
         If there are date strings or values that should be converted to a
         datetime object, list them in order here. Not processed as floats.
-        (default=[])
-    datetime_fmt : (str or NoneType)
+        NoneType produces an empty list. (default=None)
+    datetime_fmt : (str, NoneType)
         Format needed to convert the datetime_cols entries into a datetime
         object.  Special formats permitted are: 'YEAR SOY', 'SOD'.
         'YEAR SOY' must be used together; 'SOD' indicates seconds of day, and
         may be used with any date format (default=None)
-    int_cols : (list of ints)
-        Data that should be processed as integers, not floats. (default=[])
-    str_cols : (list of ints)
-        Data that should be processed as strings, not floats. (default=[])
+    int_cols : (list, NoneType)
+        Data that should be processed as integers, not floats. NoneType
+        produces an empty list. (default=None)
+    str_cols : (list, NoneType)
+        Data that should be processed as strings, not floats. NoneType produces
+        an empty list. (default=None)
     max_str_length : (int)
         Maximum allowed string length. (default=50)
-    header : (list of str)
+    header : (list, NoneType)
         Header string(s) where the last line contains whitespace separated data
-        names (default=list())
+        names. NoneType produces an empty list. (default=None)
 
     Returns
     -------
@@ -101,6 +103,18 @@ def load_ascii_data(filename, hlines, gft_kwargs=dict(), hsplit=None,
     Data is assumed to be float unless otherwise stated.
 
     """
+    # Initialize the empty lists
+    if datetime_cols is None:
+        datetime_cols = list()
+
+    if int_cols is None:
+        int_cols = list()
+
+    if str_cols is None:
+        str_cols = list()
+
+    if header is None:
+        header = list()
 
     # Test to ensure the file is small enough to read in.  Python can only
     # allocate 2GB of data.  If you load something larger, python will crash

--- a/ocbpy/instruments/general.py
+++ b/ocbpy/instruments/general.py
@@ -12,7 +12,6 @@ load_ascii_data(filename, hlines, kwargs)
     Load time-sorted ascii data file
 
 """
-from __future__ import absolute_import, unicode_literals
 
 import numpy as np
 from os import path

--- a/ocbpy/instruments/pysat_instruments.py
+++ b/ocbpy/instruments/pysat_instruments.py
@@ -16,7 +16,6 @@ Module
 pysat is available at: http://github.com/pysat/pysat or pypi
 
 """
-from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
 import numpy as np

--- a/ocbpy/instruments/supermag.py
+++ b/ocbpy/instruments/supermag.py
@@ -18,7 +18,6 @@ SuperMAG data available at: http://supermag.jhuapl.edu/
 
 """
 
-from __future__ import absolute_import, unicode_literals
 import datetime as dt
 import numpy as np
 

--- a/ocbpy/instruments/vort.py
+++ b/ocbpy/instruments/vort.py
@@ -17,7 +17,6 @@ Data
 Specialised SuperDARN data product, available from: gchi@bas.ac.uk
 
 """
-from __future__ import absolute_import, unicode_literals
 import datetime as dt
 import numpy as np
 

--- a/ocbpy/ocb_scaling.py
+++ b/ocbpy/ocb_scaling.py
@@ -30,7 +30,6 @@ Research: Space Physics, 122, doi:10.1002/2016JA023235.
 
 """
 
-from __future__ import absolute_import, unicode_literals
 import numpy as np
 
 import ocbpy

--- a/ocbpy/ocboundary.py
+++ b/ocbpy/ocboundary.py
@@ -29,7 +29,6 @@ Chisham, G. (2017), A new methodology for the development of high-latitude
  Research: Space Physics, 122, doi:10.1002/2016JA023235.
 
 """
-from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
 import numpy as np

--- a/ocbpy/tests/test_dmsp_ssj_files.py
+++ b/ocbpy/tests/test_dmsp_ssj_files.py
@@ -4,7 +4,6 @@
 # Full license can be found in License.md
 # -----------------------------------------------------------------------------
 """ Tests the boundaries.dmsp_ssj_files functions"""
-from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
 from glob import glob
@@ -12,7 +11,6 @@ from io import StringIO
 import logging
 import numpy as np
 import os
-import sys
 import unittest
 
 import ocbpy
@@ -33,11 +31,6 @@ class TestSSJFetch(unittest.TestCase):
                         os.path.join(self.ocb_dir, "tests", "test_data"),
                         self.sat_nums]
         self.fetch_files = list()
-
-        # Remove in 2020 when dropping support for 2.7
-        if sys.version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def tearDown(self):
         if len(self.fetch_files) > 0:
@@ -77,8 +70,6 @@ class TestSSJFetch(unittest.TestCase):
             *self.in_args)
         self.assertEqual(len(self.fetch_files), 0)
 
-    @unittest.skipIf(sys.version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_fetch_ssj_files_failure(self):
         """ Test fetch_ssj_files raising ValueError """
 
@@ -94,27 +85,6 @@ class TestSSJFetch(unittest.TestCase):
                             *self.in_args)
                 self.in_args[ii[0]] = temp
         del temp
-
-    @unittest.skipIf(sys.version_info.major == 3,
-                     'Already tested, remove in 2020')
-    def test_fetch_ssj_files_failure_fake_dir(self):
-        """ Test fetch_ssj_files raising ValueError for fake directory"""
-
-        self.in_args[2] = "fake_dir"
-        with self.assertRaisesRegexp(ValueError,
-                                     "can't find the output directory"):
-            self.fetch_files = boundaries.dmsp_ssj_files.fetch_ssj_files(
-                *self.in_args)
-
-    @unittest.skipIf(sys.version_info.major == 3,
-                     'Already tested, remove in 2020')
-    def test_fetch_ssj_files_failure_unknown_sat(self):
-        """ Test fetch_ssj_files raising ValueError for bad sat ID"""
-
-        self.in_args[-1] = [-47]
-        with self.assertRaisesRegexp(ValueError, "unknown satellite ID"):
-            self.fetch_files = boundaries.dmsp_ssj_files.fetch_ssj_files(
-                *self.in_args)
 
     def test_fetch_ssj_files_failure_bad_sat(self):
         """ Test fetch_ssj_files raising ValueError for bad sat ID"""
@@ -147,11 +117,6 @@ class TestSSJCreate(unittest.TestCase):
         ocbpy.logger.addHandler(logging.StreamHandler(self.log_capture))
         ocbpy.logger.setLevel(logging.WARNING)
 
-        # Remove in 2020 when dropping support for 2.7
-        if sys.version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
     def tearDown(self):
         if len(self.out) > 0:
             for ff in self.out:
@@ -161,8 +126,6 @@ class TestSSJCreate(unittest.TestCase):
         del self.comp_files, self.log_capture, self.lout, self.base_file
         del self.out_cols
 
-    @unittest.skipIf(sys.version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_create_ssj_boundary_files_failure(self):
         """ Test create_ssj_boundary_files raising ValueError """
 
@@ -176,52 +139,6 @@ class TestSSJCreate(unittest.TestCase):
                         boundaries.dmsp_ssj_files.create_ssj_boundary_files(
                             self.cdf_files, **ii[0])
 
-    @unittest.skipIf(sys.version_info.major == 3,
-                     'Already tested, remove in 2020')
-    def test_create_ssj_boundary_files_plotdir_failure(self):
-        """ Test create_ssj_boundary_files plot directory failure """
-
-        with self.assertRaisesRegex(ValueError, "unknown plot directory"):
-            self.out = boundaries.dmsp_ssj_files.create_ssj_boundary_files(
-                self.cdf_files, make_plots=True, plot_dir='fake_dir')
-
-    @unittest.skipIf(sys.version_info.major == 3,
-                     'Already tested, remove in 2020')
-    def test_create_ssj_boundary_files_outdir_failure(self):
-        """ Test create_ssj_boundary_files output directory failure """
-
-        with self.assertRaisesRegex(ValueError, "unknown output directory"):
-            self.out = boundaries.dmsp_ssj_files.create_ssj_boundary_files(
-                self.cdf_files, out_dir='fake_dir')
-
-    @unittest.skipIf(sys.version_info.major == 3,
-                     'Already tested, remove in 2020')
-    def test_create_ssj_boundary_files_cdfname_failure(self):
-        """ Test create_ssj_boundary_files bad cdf filename failure """
-
-        # Try to read in a bad CDF filename
-        self.out = boundaries.dmsp_ssj_files.create_ssj_boundary_files(
-            self.comp_files)
-        self.assertEqual(len(self.out), 0)
-
-        # Test the logging output
-        self.lout = self.log_capture.getvalue()
-        self.assertTrue(self.lout.find("CDF") >= 0)
-
-    @unittest.skipIf(sys.version_info.major == 3,
-                     'Already tested, remove in 2020')
-    def test_create_ssj_boundary_files_notafile_failure(self):
-        """ Test create_ssj_boundary_files bad filename failure """
-
-        # Try to read in a bad CDF filename
-        self.out = boundaries.dmsp_ssj_files.create_ssj_boundary_files(
-            [self.test_dir])
-        self.assertEqual(len(self.out), 0)
-
-        # Test the logging output
-        self.lout = self.log_capture.getvalue()
-        self.assertTrue(self.lout.find("bad input file") >= 0)
-
     def test_create_ssj_boundary_files_outcols_failure(self):
         """ Test create_ssj_boundary_files bad outcols failure """
 
@@ -229,8 +146,6 @@ class TestSSJCreate(unittest.TestCase):
             self.out = boundaries.dmsp_ssj_files.create_ssj_boundary_files(
                 self.cdf_files, out_dir=self.test_dir, out_cols=['fake'])
 
-    @unittest.skipIf(sys.version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_create_ssj_boundary_files_log_failure(self):
         """ Test create_ssj_boundary_files raising logging errors """
 
@@ -366,11 +281,6 @@ class TestSSJFormat(unittest.TestCase):
         self.log_capture = StringIO()
         ocbpy.logger.addHandler(logging.StreamHandler(self.log_capture))
         ocbpy.logger.setLevel(logging.WARNING)
-
-        # Remove in 2020 when dropping support for 2.7
-        if sys.version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def tearDown(self):
         if len(self.out) > 0:
@@ -512,10 +422,6 @@ class TestSSJFetchFormat(unittest.TestCase):
         self.ldtype = [int, '|U50', '|U50', float, float, float,
                        float, float, float, float, float]
 
-        # Remove in 2020 when dropping support for 2.7
-        if sys.version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
     def tearDown(self):
         if len(self.out) > 0:
             for ff in self.out:
@@ -638,10 +544,8 @@ class TestSSJFetchFormat(unittest.TestCase):
                  "ssj_auroral_boundary installed, cannot test failure")
 class TestSSJFailure(unittest.TestCase):
     def setUp(self):
-        """ Set up calls for python 2.7 """
-        # Remove in 2020 when dropping support for 2.7
-        if sys.version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+        """ No setup needed"""
+        pass
 
     def tearDown(self):
         """ No teardown needed"""
@@ -652,4 +556,4 @@ class TestSSJFailure(unittest.TestCase):
 
         with self.assertRaisesRegex(ImportError,
                                     'unable to load the DMSP SSJ module'):
-            from ocbpy.boundaries import dmsp_ssj_files
+            from ocbpy.boundaries import dmsp_ssj_files  # NOQA F401

--- a/ocbpy/tests/test_files.py
+++ b/ocbpy/tests/test_files.py
@@ -5,13 +5,11 @@
 # -----------------------------------------------------------------------------
 """ Tests the boundaries.files functions
 """
-from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
 from io import StringIO
 import logging
 import os
-from sys import version_info
 import unittest
 
 import ocbpy
@@ -148,10 +146,6 @@ class TestFilesMethods(unittest.TestCase):
         self.ikey = ''
         self.fname = None
 
-        # Remove in 2020 when dropping support for 2.7
-        if version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
-
     def tearDown(self):
         if ocbpy.__file__ != self.orig_file:
             ocbpy.__file__ = self.orig_file
@@ -203,8 +197,6 @@ class TestFilesMethods(unittest.TestCase):
         self.assertRegex(self.out[0], 'si13_north_circle.ocb')
         self.assertRegex(self.out[1], 'image')
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_get_default_file_none_north_all(self):
         """ Test get_default_file with no range, northern hemisphere"""
 
@@ -236,91 +228,6 @@ class TestFilesMethods(unittest.TestCase):
                     self.assertRegex(self.out[0], self.fname)
                 self.assertRegex(self.out[1], iname)
 
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_north_any(self):
-        """ Test get_default_file with no range, northern hemisphere, any inst
-        """
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        if self.long_to_short[self.ikey] is not None:
-            self.fname = "{:s}_north".format(self.long_to_short[self.ikey])
-
-        self.assertRegex(self.out[0], self.fname)
-        self.assertRegex(self.out[1], self.short_to_long[self.ikey])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_north_si12(self):
-        """ Test get_default_file with no range, northern hemisphere, any inst
-        """
-        self.ikey = 'si12'
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.assertRegex(self.out[0], "{:s}_north".format(self.ikey))
-        self.assertRegex(self.out[1], self.short_to_long[self.ikey])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_north_si13(self):
-        """ Test get_default_file with no range, northern hemisphere, any inst
-        """
-        self.ikey = 'si13'
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.assertRegex(self.out[0], "{:s}_north".format(self.ikey))
-        self.assertRegex(self.out[1], self.short_to_long[self.ikey])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_north_wic(self):
-        """ Test get_default_file with no range, northern hemisphere, any inst
-        """
-        self.ikey = 'wic'
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.assertRegex(self.out[0], "{:s}_north".format(self.ikey))
-        self.assertRegex(self.out[1], self.short_to_long[self.ikey])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_north_image(self):
-        """ Test get_default_file with no range, northern hemisphere, any inst
-        """
-        self.ikey = 'image'
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.fname = "{:s}_north".format(self.long_to_short[self.ikey])
-
-        self.assertRegex(self.out[0], self.fname)
-        self.assertRegex(self.out[1], self.ikey)
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_north_ampere(self):
-        """ Test get_default_file with no range, northern hemisphere, any inst
-        """
-        self.ikey = 'ampere'
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.fname = "{:s}_north".format(self.long_to_short[self.ikey])
-
-        self.assertRegex(self.out[0], self.fname)
-        self.assertRegex(self.out[1], self.ikey)
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_north_amp(self):
-        """ Test get_default_file with no range, northern hemisphere, any inst
-        """
-        self.ikey = 'amp'
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.assertRegex(self.out[0], "{:s}_north".format(self.ikey))
-        self.assertRegex(self.out[1], self.short_to_long[self.ikey])
-
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_get_default_file_none_south_all(self):
         """ Test get_default_file with no range, southern hemisphere"""
         # Set the southern hemisphere defaults
@@ -356,57 +263,6 @@ class TestFilesMethods(unittest.TestCase):
                     self.assertRegex(self.out[0], self.fname)
                 self.assertRegex(self.out[1], iname)
 
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_south_any(self):
-        """ Test get_default_file with no range, southern hemisphere, any inst
-        """
-        # Set the southern hemisphere defaults
-        self.hemi = -1
-        self.long_to_short[''] = 'amp'
-        self.short_to_long[''] = 'ampere'
-
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.fname = "{:s}_south".format(self.long_to_short[self.ikey])
-
-        self.assertRegex(self.out[0], self.fname)
-        self.assertRegex(self.out[1], self.short_to_long[self.ikey])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_south_ampere(self):
-        """ Test get_default_file with no range, southern hemisphere, any inst
-        """
-        # Set the southern hemisphere defaults
-        self.hemi = -1
-
-        self.ikey = 'ampere'
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.fname = "{:s}_south".format(self.long_to_short[self.ikey])
-
-        self.assertRegex(self.out[0], self.fname)
-        self.assertRegex(self.out[1], self.ikey)
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_none_south_amp(self):
-        """ Test get_default_file with no range, southern hemisphere, any inst
-        """
-        # Set the southern hemisphere defaults
-        self.hemi = -1
-        self.long_to_short[''] = 'amp'
-        self.short_to_long[''] = 'ampere'
-
-        self.ikey = 'amp'
-        self.out = files.get_default_file(None, None, self.hemi,
-                                          instrument=self.ikey)
-
-        self.assertRegex(self.out[0], "{:s}_south".format(self.ikey))
-        self.assertRegex(self.out[1], self.short_to_long[self.ikey])
-
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_get_default_good_file_times(self):
         """ Test get_default_file with good ranges"""
         # Cycle through all possible instrument names
@@ -425,30 +281,6 @@ class TestFilesMethods(unittest.TestCase):
 
                 self.assertRegex(self.out[0], ii)
                 self.assertRegex(self.out[1], iname)
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_good_file_times_ampere(self):
-        """ Test get_default_file with good ranges for ampere
-        """
-        self.ikey = 'amp_north_radii.ocb'
-        self.out = files.get_default_file(self.comp_dict[self.ikey]['stime'],
-                                          self.comp_dict[self.ikey]['etime'],
-                                          self.hemi)
-
-        self.assertRegex(self.out[0], self.ikey)
-        self.assertRegex(self.out[1], self.comp_dict[self.ikey]['instrument'])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_get_default_file_good_file_times_image(self):
-        """ Test get_default_file with good ranges for image
-        """
-        self.ikey = 'si13_north_circle.ocb'
-        self.out = files.get_default_file(self.comp_dict[self.ikey]['stime'],
-                                          self.comp_dict[self.ikey]['etime'],
-                                          self.hemi)
-
-        self.assertRegex(self.out[0], self.ikey)
-        self.assertRegex(self.out[1], 'image')
 
     def test_get_default_file_bad_file_times(self):
         """ Test get_default_file with bad time ranges

--- a/ocbpy/tests/test_general.py
+++ b/ocbpy/tests/test_general.py
@@ -5,7 +5,6 @@
 # -----------------------------------------------------------------------------
 """ Tests the ocb_scaling class and functions
 """
-from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
 import logging

--- a/ocbpy/tests/test_ocb_correction.py
+++ b/ocbpy/tests/test_ocb_correction.py
@@ -7,7 +7,6 @@
 """
 
 import numpy as np
-from sys import version_info
 import unittest
 
 from ocbpy import ocb_correction as ocb_cor
@@ -26,8 +25,6 @@ class TestOCBCorrectionFailure(unittest.TestCase):
         """ Tear down the test runs """
         del self.mlt, self.bad_kwarg, self.functions, self.bound
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_instrument_failure(self):
         """ Test failure when an unknown instrument is provided """
 
@@ -37,44 +34,12 @@ class TestOCBCorrectionFailure(unittest.TestCase):
                     self.functions[self.bound](self.mlt,
                                                instrument=self.bad_kwarg)
 
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_elliptical_instrument_failure(self):
-        """ Test failure in elliptical when an unknown instrument is provided
-        """
-        self.bound = 'elliptical'
-        with self.assertRaises(ValueError):
-            self.functions[self.bound](self.mlt, instrument=self.bad_kwarg)
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_harmonic_instrument_failure(self):
-        """ Test failure in harmonic when an unknown instrument is provided"""
-
-        self.bound = 'harmonic'
-        with self.assertRaises(ValueError):
-            self.functions[self.bound](self.mlt, instrument=self.bad_kwarg)
-
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_method_failure(self):
         """ Test failure when an unknown method is provided """
         for self.bound in self.functions.keys():
             with self.subTest(bound=self.bound):
                 with self.assertRaises(ValueError):
                     self.functions[self.bound](self.mlt, method=self.bad_kwarg)
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_elliptical_method_failure(self):
-        """ Test failure in elliptical when an unknown method is provided"""
-        self.bound = 'elliptical'
-        with self.assertRaises(ValueError):
-            self.functions[self.bound](self.mlt, method=self.bad_kwarg)
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_harmonic_method_failure(self):
-        """ Test failure in harmonic when an unknown method is provided"""
-        self.bound = 'harmonic'
-        with self.assertRaises(ValueError):
-            self.functions[self.bound](self.mlt, method=self.bad_kwarg)
 
 
 class TestOCBCorrection(unittest.TestCase):
@@ -98,8 +63,6 @@ class TestOCBCorrection(unittest.TestCase):
         del self.mlt, self.functions, self.def_results, self.gaus_results
         del self.bound
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_default_float(self):
         """ Test the boundary functions using a float and function defaults"""
         for self.bound in self.functions.keys():
@@ -107,29 +70,6 @@ class TestOCBCorrection(unittest.TestCase):
                 self.assertEqual(self.functions[self.bound](self.mlt[0]),
                                  self.def_results[self.bound][0])
 
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_circular_default_float(self):
-        """ Test the default circular boundary function with a float"""
-        self.bound = 'circular'
-        self.assertEqual(self.functions[self.bound](self.mlt[0]),
-                         self.def_results[self.bound][0])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_ampere_harmonic_float(self):
-        """ Test the default harmonic boundary function for a value"""
-        self.bound = 'harmonic'
-        self.assertEqual(self.functions[self.bound](self.mlt[0]),
-                         self.def_results[self.bound][0])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_ampere_elliptical_float(self):
-        """ Test the default elliptical boundary function for a value"""
-        self.bound = 'elliptical'
-        self.assertEqual(self.functions[self.bound](self.mlt[0]),
-                         self.def_results[self.bound][0])
-
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_default_arr(self):
         """ Test the boundary functions using an array and function defaults"""
         for self.bound in self.functions.keys():
@@ -138,33 +78,10 @@ class TestOCBCorrection(unittest.TestCase):
                     abs(self.functions[self.bound](self.mlt)
                         - self.def_results[self.bound]) < 1.0e-7))
 
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_circular_default_arr(self):
-        """ Test the default circular boundary function with an array"""
-        self.bound = 'circular'
-        self.assertTrue(np.all(self.functions[self.bound](self.mlt)
-                               == self.def_results[self.bound]))
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_ampere_elliptical_arr(self):
-        """ Test the default elliptical boundary function for an array"""
-        self.bound = 'elliptical'
-        self.assertTrue(np.all(abs(self.functions[self.bound](self.mlt)
-                                   - self.def_results[self.bound]) < 1.0e-7))
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_ampere_harmonic_arr(self):
-        """ Test the default harmonic boundary function for an array"""
-        self.bound = 'harmonic'
-        self.assertTrue(np.all(abs(self.functions[self.bound](self.mlt)
-                                   - self.def_results[self.bound]) < 1.0e-7))
-
     def test_circular_offset(self):
         """ Test the circular boundary function with an offset """
         self.assertEqual(ocb_cor.circular(self.mlt[0], r_add=1.0), 1.0)
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_gauss_method(self):
         """ Test the boundary functions using an array and function defaults"""
         for self.bound in self.gaus_results.keys():
@@ -172,19 +89,3 @@ class TestOCBCorrection(unittest.TestCase):
                 self.assertAlmostEqual(
                     self.functions[self.bound](self.mlt[0], method='gaussian'),
                     self.gaus_results[self.bound])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_ampere_harmonic_gaussian(self):
-        """ Test the gaussian harmonic boundary function """
-        self.bound = 'harmonic'
-        self.assertAlmostEqual(self.functions[self.bound](self.mlt[0],
-                                                          method="gaussian"),
-                               self.gaus_results[self.bound])
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_elliptical_gaussian(self):
-        """ Test the gaussian elliptical boundary function """
-        self.bound = 'elliptical'
-        self.assertAlmostEqual(self.functions[self.bound](self.mlt[0],
-                                                          method="gaussian"),
-                               self.gaus_results[self.bound])

--- a/ocbpy/tests/test_ocb_scaling.py
+++ b/ocbpy/tests/test_ocb_scaling.py
@@ -10,7 +10,6 @@ from io import StringIO
 import logging
 import numpy as np
 from os import path
-from sys import version_info
 import unittest
 
 import ocbpy
@@ -103,9 +102,6 @@ class TestOCBScalingMethods(unittest.TestCase):
                                                   aacgm_e=0.0,
                                                   dat_name="Test Zero",
                                                   dat_units="$m s^{-1}$")
-
-        if version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
 
     def tearDown(self):
         del self.ocb, self.vdata, self.wdata, self.zdata
@@ -386,8 +382,6 @@ class TestOCBScalingMethods(unittest.TestCase):
                          self.vdata.scale_func(0.0, self.vdata.unscaled_r,
                                                self.vdata.scaled_r))
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_scale_vec_pole_angle_zero(self):
         """ Test the calculation of the OCB vector sign with no pole angle
         """
@@ -419,44 +413,6 @@ class TestOCBScalingMethods(unittest.TestCase):
                 self.assertEqual(self.vdata.ocb_e, tset[3])
 
         del nscale, escale, tset
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested')
-    def test_scale_vec_pole_angle_zero_none(self):
-        """ Test the OCB vector sign routine with no pole angle or scaling
-        """
-        self.vdata.set_ocb(self.ocb)
-        self.vdata.pole_angle = 0.0
-
-        # Run the scale_vector routine with the new attributes
-        self.vdata.scale_vector()
-
-        # Assess the ocb north and east components
-        self.assertEqual(self.vdata.ocb_n, self.vdata.aacgm_n)
-        self.assertEqual(self.vdata.ocb_e, self.vdata.aacgm_e)
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested')
-    def test_scale_vec_pole_angle_zero_scale_at_pole(self):
-        """ Test the OCB vector sign routine with no pole angle and data at pole
-        """
-        self.vdata.set_ocb(self.ocb, scale_func=ocbpy.ocb_scaling.normal_evar)
-        self.vdata.pole_angle = 0.0
-        self.vdata.ocb_aacgm_lat = self.vdata.aacgm_lat
-
-        nscale = -1.0 * ocbpy.ocb_scaling.normal_evar(self.vdata.aacgm_n,
-                                                      self.vdata.unscaled_r,
-                                                      self.vdata.scaled_r)
-        escale = -1.0 * ocbpy.ocb_scaling.normal_evar(self.vdata.aacgm_e,
-                                                      self.vdata.unscaled_r,
-                                                      self.vdata.scaled_r)
-
-        # Run the scale_vector routine with the new attributes
-        self.vdata.scale_vector()
-
-        # Assess the ocb north and east components
-        self.assertEqual(self.vdata.ocb_n, nscale)
-        self.assertEqual(self.vdata.ocb_e, escale)
-
-        del nscale, escale
 
     def test_set_ocb_zero(self):
         """ Test setting of OCB values in VectorData without any magnitude
@@ -526,9 +482,6 @@ class TestVectorDataRaises(unittest.TestCase):
         self.raise_out = list()
         self.hold_val = None
 
-        if version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
     def tearDown(self):
         del self.ocb, self.vdata, self.input_attrs, self.bad_input
         del self.raise_out, self.hold_val
@@ -559,8 +512,6 @@ class TestVectorDataRaises(unittest.TestCase):
             self.vdata = ocbpy.ocb_scaling.VectorData(*self.input_attrs,
                                                       **self.bad_input)
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_init_vector_failure(self):
         """ Test init failure with a bad mix of vector and scalar input
         """
@@ -582,45 +533,6 @@ class TestVectorDataRaises(unittest.TestCase):
                     self.vdata = ocbpy.ocb_scaling.VectorData(*tset[0],
                                                               **tset[1])
 
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_init_vector_failure_dat_ind(self):
-        """ Test init failure with a bad data index shape
-        """
-        self.input_attrs = [0, self.ocb.rec_ind, [75.0, 70.0], [22.0, 20.0]]
-        self.bad_input = {'aacgm_n': 10.0}
-
-        with self.assertRaisesRegex(
-                ValueError, "data index shape must match vector shape"):
-            self.vdata = ocbpy.ocb_scaling.VectorData(*self.input_attrs,
-                                                      **self.bad_input)
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_init_vector_failure_many_array_size(self):
-        """ Test init failure with a bad vector lengths
-        """
-        self.input_attrs = [[0, 1], self.ocb.rec_ind, [75.0, 70.0], 20.0]
-        self.bad_input = {'aacgm_n': [100.0, 110.0, 30.0]}
-
-        with self.assertRaisesRegex(ValueError,
-                                    "mismatched VectorData input shapes"):
-            self.vdata = ocbpy.ocb_scaling.VectorData(*self.input_attrs,
-                                                      **self.bad_input)
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_init_vector_failure_bad_lat_array_size(self):
-        """ Test init failure with a bad vector lengths
-        """
-        self.input_attrs = [[0, 1, 3], self.ocb.rec_ind, [75.0, 70.0],
-                            [22.0, 20.0, 23.0]]
-        self.bad_input = {'aacgm_n': [100.0, 110.0, 30.0]}
-
-        with self.assertRaisesRegex(ValueError,
-                                    "mismatched VectorData input shapes"):
-            self.vdata = ocbpy.ocb_scaling.VectorData(*self.input_attrs,
-                                                      **self.bad_input)
-
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_bad_calc_vec_pole_angle(self):
         """Test calc_vec_pole_angle failure with bad input"""
         self.input_attrs = ['aacgm_mlt', 'ocb_aacgm_mlt', 'aacgm_lat',
@@ -642,86 +554,6 @@ class TestVectorDataRaises(unittest.TestCase):
                     self.vdata.calc_vec_pole_angle()
 
                 setattr(self.vdata, tset[0], self.hold_val)
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_bad_calc_vec_pole_angle_mlt_float(self):
-        """Test calc_vec_pole_angle failure with bad AACGM MLT
-        """
-        self.vdata.set_ocb(self.ocb, None)
-        self.vdata.aacgm_mlt = self.bad_input[0]
-
-        with self.assertRaisesRegex(ValueError, "AACGM MLT of Vector"):
-            self.vdata.calc_vec_pole_angle()
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_bad_calc_vec_pole_angle_ocb_mlt_float_small(self):
-        """Test calc_vec_pole_angle failure with small bad OCB MLT
-        """
-        self.vdata.set_ocb(self.ocb, None)
-        self.vdata.ocb_aacgm_mlt = self.bad_input[0]
-
-        with self.assertRaisesRegex(ValueError, "AACGM MLT of OCB pole"):
-            self.vdata.calc_vec_pole_angle()
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_bad_calc_vec_pole_angle_vec_mlat_float(self):
-        """Test calc_vec_pole_angle failure with bad vector latitude
-        """
-        self.vdata.set_ocb(self.ocb, None)
-        self.vdata.aacgm_lat = self.bad_input[0]
-
-        with self.assertRaisesRegex(ValueError, "AACGM latitude of Vector"):
-            self.vdata.calc_vec_pole_angle()
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_bad_calc_vec_pole_angle_mlt_array(self):
-        """Test calc_vec_pole_angle failure with bad AACGM MLT
-        """
-        self.vdata.set_ocb(self.ocb, None)
-        self.vdata.aacgm_mlt = self.bad_input[1]
-
-        with self.assertRaisesRegex(ValueError, "AACGM MLT of Vector"):
-            self.vdata.calc_vec_pole_angle()
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_bad_calc_vec_pole_angle_ocb_mlt_float_big(self):
-        """Test calc_vec_pole_angle failure with bad OCB MLT
-        """
-        self.vdata.set_ocb(self.ocb, None)
-        self.vdata.ocb_aacgm_mlt = self.bad_input[1]
-
-        with self.assertRaisesRegex(ValueError, "AACGM MLT of OCB pole"):
-            self.vdata.calc_vec_pole_angle()
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_bad_calc_vec_pole_angle_ocb_mlat_float_small(self):
-        """Test calc_vec_pole_angle failure with barely bad OCB latitude
-        """
-        self.vdata.set_ocb(self.ocb, None)
-        self.vdata.ocb_aacgm_lat = self.bad_input[0]
-
-        with self.assertRaisesRegex(ValueError, "AACGM latitude of OCB pole"):
-            self.vdata.calc_vec_pole_angle()
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_bad_calc_vec_pole_angle_ocb_mlat_float_big(self):
-        """Test calc_vec_pole_angle failure with bad OCB latitude
-        """
-        self.vdata.set_ocb(self.ocb, None)
-        self.vdata.ocb_aacgm_lat = self.bad_input[1]
-
-        with self.assertRaisesRegex(ValueError, "AACGM latitude of OCB pole"):
-            self.vdata.calc_vec_pole_angle()
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_bad_calc_vec_aacgm_lat_float(self):
-        """Test calc_vec_pole_angle failure with bad vector latitude
-        """
-        self.vdata.set_ocb(self.ocb, None)
-        self.vdata.aacgm_lat = self.bad_input[1]
-
-        with self.assertRaisesRegex(ValueError, "AACGM latitude of Vector"):
-            self.vdata.calc_vec_pole_angle()
 
     def test_no_ocb_lat(self):
         """ Test failure when OCB latitude is not available
@@ -887,8 +719,6 @@ class TestHaversine(unittest.TestCase):
     def tearDown(self):
         del self.input_angles, self.hav_out, self.out, self.ahav_out
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_haversine(self):
         """ Test implimentation of the haversine
         """
@@ -907,31 +737,6 @@ class TestHaversine(unittest.TestCase):
 
         del tset
 
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_haversine_float(self):
-        """ Test implimentation of the haversine with float inputs
-        """
-
-        for i, alpha in enumerate(self.input_angles):
-            self.assertAlmostEqual(ocbpy.ocb_scaling.hav(alpha),
-                                   self.hav_out[i])
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_haversine_list(self):
-        """ Test implimentation of the haversine with a list input
-        """
-        self.out = ocbpy.ocb_scaling.hav(list(self.input_angles))
-        self.assertTrue(np.all(abs(self.out - self.hav_out) < 1.0e-7))
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_haversine_array(self):
-        """ Test implimentation of the haversine with a array input
-        """
-        self.out = ocbpy.ocb_scaling.hav(self.input_angles)
-        self.assertTrue(np.all(abs(self.out - self.hav_out) < 1.0e-7))
-
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_inverse_haversine(self):
         """ Test the implemenation of the inverse haversine
         """
@@ -949,32 +754,6 @@ class TestHaversine(unittest.TestCase):
                     self.assertTrue(np.all(self.out - tset[1] < 1.0e-7))
 
         del tset
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_inverse_haversine_float(self):
-        """ Test implimentation of the inverse haversine with float input
-        """
-        for i, self.out in enumerate(self.ahav_out):
-            self.assertAlmostEqual(ocbpy.ocb_scaling.archav(self.hav_out[i]),
-                                   self.out)
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_inverse_haversine_list(self):
-        """ Test implimentation of the inverse haversine with list input
-        """
-        self.out = ocbpy.ocb_scaling.archav(list(self.hav_out))
-        self.assertTrue(np.all(abs(self.out - self.ahav_out)
-                               < 1.0e-7))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_inverse_haversine_array(self):
-        """ Test implimentation of the inverse haversine with array input
-        """
-        self.out = ocbpy.ocb_scaling.archav(self.hav_out)
-        self.assertTrue(np.all(abs(self.out - self.ahav_out) < 1.0e-7))
 
     def test_inverse_haversine_small_float(self):
         """ Test implimentation of the inverse haversine with very small numbers
@@ -1040,7 +819,7 @@ class TestOCBScalingArrayMethods(unittest.TestCase):
                                   4, 4],
                           'vec': [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3,
                                   4, 1]}
-        
+
         self.vargs = [np.arange(0, 17, 1), 27, lats, mlts]
         self.vkwargs = {'aacgm_n': np.array(north), 'aacgm_e': np.array(east),
                         'aacgm_z': np.array(vert), 'dat_name': 'Test',
@@ -1051,10 +830,6 @@ class TestOCBScalingArrayMethods(unittest.TestCase):
         self.aacgm_mag = np.full(shape=(17,), fill_value=10.44030650891055)
         self.aacgm_mag[0] = 11.575836902790225
         self.aacgm_mag[-1] = 0.0
-
-        if version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
-            self.assertNotRegex = self.assertNotRegexpMatches
 
     def tearDown(self):
         del self.ocb, self.vargs, self.vkwargs, self.out, self.vdata
@@ -1279,8 +1054,6 @@ class TestOCBScalingArrayMethods(unittest.TestCase):
         self.assertEqual(list(self.vdata.ocb_quad), self.ref_quads['ocb'])
         self.assertEqual(list(self.vdata.vec_quad), self.ref_quads['vec'])
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_scale_vec_pole_angle_zero(self):
         """ Test the calculation of the OCB vector sign with no pole angle
         """
@@ -1315,42 +1088,3 @@ class TestOCBScalingArrayMethods(unittest.TestCase):
                 self.assertTrue(np.all(self.vdata.ocb_e == tset[3]))
 
         del nscale, escale, tset
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_scale_vec_pole_angle_zero_noscale(self):
-        """ Test the OCB vector sign calc with no pole angle or scaling
-        """
-        self.vdata = ocbpy.ocb_scaling.VectorData(*self.vargs, **self.vkwargs)
-        self.vdata.set_ocb(self.ocb)
-        self.vdata.pole_angle = np.zeros(shape=self.vargs[2].shape)
-        self.vdata.pole_angle[self.vdata.ocb_quad > 2] = 180.0
-
-        # Run the scale_vector routine with the new attributes
-        self.vdata.scale_vector()
-
-        # Assess the ocb north and east components
-        self.assertTrue(np.all(self.vdata.ocb_n == self.vkwargs['aacgm_n']))
-        self.assertTrue(np.all(self.vdata.ocb_e == self.vkwargs['aacgm_e']))
-
-    @unittest.skipIf(version_info.major > 2, 'Already tested with subTest')
-    def test_scale_vec_pole_angle_zero_scale(self):
-        """  Test the OCB vector sign calc with scaling but no pole angle
-        """
-        self.vdata = ocbpy.ocb_scaling.VectorData(*self.vargs, **self.vkwargs)
-        self.vdata.set_ocb(self.ocb, scale_func=ocbpy.ocb_scaling.normal_evar)
-        self.vdata.pole_angle = np.zeros(shape=self.vargs[2].shape)
-        self.vdata.pole_angle[self.vdata.ocb_quad > 2] = 180.0
-
-        # Run the scale_vector routine with the new attributes
-        self.vdata.scale_vector()
-
-        # Assess the ocb north and east components
-        self.out = ocbpy.ocb_scaling.normal_evar(self.vkwargs['aacgm_n'],
-                                                 self.vdata.unscaled_r,
-                                                 self.vdata.scaled_r)
-        self.assertTrue(np.all(self.vdata.ocb_n == self.out))
-
-        self.out = ocbpy.ocb_scaling.normal_evar(self.vkwargs['aacgm_e'],
-                                                 self.vdata.unscaled_r,
-                                                 self.vdata.scaled_r)
-        self.assertTrue(np.all(self.vdata.ocb_e == self.out))

--- a/ocbpy/tests/test_ocb_time.py
+++ b/ocbpy/tests/test_ocb_time.py
@@ -8,7 +8,6 @@
 
 import datetime as dt
 import numpy as np
-from sys import version_info
 import unittest
 
 from ocbpy import ocb_time
@@ -20,9 +19,6 @@ class TestOCBTimeMethods(unittest.TestCase):
 
         self.dtime = dt.datetime(2001, 1, 1)
         self.dtime2 = dt.datetime(1901, 1, 1)
-
-        if version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def tearDown(self):
         """ Clean up after each test """
@@ -327,8 +323,6 @@ class TestTimeFormatMethods(unittest.TestCase):
         """ Clean up after each test """
         del self.dt_formats, self.dtime, self.out_fmt, self.out_len
 
-    @unittest.skipIf(version_info.major < 3,
-                     'Already tested, remove in 2020')
     def test_get_datetime_fmt_len(self):
         """ Test the datetime format length determination"""
         # Cycle through the different formatting options
@@ -344,104 +338,6 @@ class TestTimeFormatMethods(unittest.TestCase):
                 # equal to the formatted time string
                 self.assertGreaterEqual(self.out_len, len(self.out_fmt))
 
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_get_datetime_fmt_len_nodate(self):
-        """ Test the datetime format length determination for string w/o date
-        """
-        # Get the function format string length maximum
-        self.out_len = ocb_time.get_datetime_fmt_len(self.dt_formats[0])
-
-        # Get the formatted time string
-        self.out_fmt = self.dtime.strftime(self.dt_formats[0])
-
-        # Test to see that the returned length equalsthe formatted time string
-        self.assertEqual(self.out_len, len(self.out_fmt))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_get_datetime_fmt_len_samelength(self):
-        """ Test the datetime format length cal for a string of the same length
-        """
-        # Get the function format string length maximum
-        self.out_len = ocb_time.get_datetime_fmt_len(self.dt_formats[1])
-
-        # Get the formatted time string
-        self.out_fmt = self.dtime.strftime(self.dt_formats[1])
-
-        # Test to see that the returned length equalsthe formatted time string
-        self.assertEqual(self.out_len, len(self.out_fmt))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_get_datetime_fmt_len_abYf(self):
-        """ Test the datetime format length calc for the %a %b %Y %f directives
-        """
-        # Get the function format string length maximum
-        self.out_len = ocb_time.get_datetime_fmt_len(self.dt_formats[2])
-
-        # Get the formatted time string
-        self.out_fmt = self.dtime.strftime(self.dt_formats[2])
-
-        # Test to see that the returned length equalsthe formatted time string
-        self.assertGreaterEqual(self.out_len, len(self.out_fmt))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_get_datetime_fmt_len_ABzZ(self):
-        """ Test the datetime format length calc for the %A %B %z %Z directives
-        """
-        # Get the function format string length maximum
-        self.out_len = ocb_time.get_datetime_fmt_len(self.dt_formats[3])
-
-        # Get the formatted time string
-        self.out_fmt = self.dtime.strftime(self.dt_formats[3])
-
-        # Test to see that the returned length equalsthe formatted time string
-        self.assertGreaterEqual(self.out_len, len(self.out_fmt))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_get_datetime_fmt_len_c(self):
-        """ Test the datetime format length calc for the %c directive
-        """
-        # Get the function format string length maximum
-        self.out_len = ocb_time.get_datetime_fmt_len(self.dt_formats[4])
-
-        # Get the formatted time string
-        self.out_fmt = self.dtime.strftime(self.dt_formats[4])
-
-        # Test to see that the returned length equalsthe formatted time string
-        self.assertGreaterEqual(self.out_len, len(self.out_fmt))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_get_datetime_fmt_len_x(self):
-        """ Test the datetime format length calc for the %x directive
-        """
-        # Get the function format string length maximum
-        self.out_len = ocb_time.get_datetime_fmt_len(self.dt_formats[5])
-
-        # Get the formatted time string
-        self.out_fmt = self.dtime.strftime(self.dt_formats[5])
-
-        # Test to see that the returned length equalsthe formatted time string
-        self.assertGreaterEqual(self.out_len, len(self.out_fmt))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_get_datetime_fmt_len_X(self):
-        """ Test the datetime format length calc for the %X directive
-        """
-        # Get the function format string length maximum
-        self.out_len = ocb_time.get_datetime_fmt_len(self.dt_formats[6])
-
-        # Get the formatted time string
-        self.out_fmt = self.dtime.strftime(self.dt_formats[6])
-
-        # Test to see that the returned length equalsthe formatted time string
-        self.assertGreaterEqual(self.out_len, len(self.out_fmt))
-
 
 class TestFixRange(unittest.TestCase):
     def setUp(self):
@@ -449,9 +345,6 @@ class TestFixRange(unittest.TestCase):
 
         self.vals = np.linspace(-190.0, 360.0, 37)
         self.out = None
-
-        if version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def tearDown(self):
         """ Clean up after each test """
@@ -468,8 +361,6 @@ class TestFixRange(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Value range must be greater"):
             ocb_time.fix_range(self.vals, -10.0, 10.0, 0.0)
 
-    @unittest.skipIf(version_info.major < 3,
-                     'Already tested, remove in 2020')
     def test_fix_range(self):
         """ Test fix_range success """
         for tset in [([self.vals, 0.0, 360.0], {}),
@@ -482,48 +373,3 @@ class TestFixRange(unittest.TestCase):
 
                 self.assertTrue(np.all(np.greater_equal(self.out, tset[0][1])))
                 self.assertTrue(np.all(np.less(self.out, tset[0][2])))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_fix_range_default_array(self):
-        """ Test fix_range success for array input and default value range
-        """
-        self.out = ocb_time.fix_range(self.vals, 0.0, 360.0)
-        self.assertTrue(np.all(np.greater_equal(self.out, 0.0)))
-        self.assertTrue(np.all(np.less(self.out, 360.0)))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_fix_range_default_list(self):
-        """ Test fix_range success for list input and default value range
-        """
-        self.out = ocb_time.fix_range(list(self.vals), 0.0, 360.0)
-        self.assertTrue(np.all(np.greater_equal(self.out, 0.0)))
-        self.assertTrue(np.all(np.less(self.out, 360.0)))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_fix_range_set_range_array(self):
-        """ Test fix_range success for array input and specified value range
-        """
-        self.out = ocb_time.fix_range(self.vals, -180.0, 360.0, 360.0)
-        self.assertTrue(np.all(np.greater_equal(self.out, -180.0)))
-        self.assertTrue(np.all(np.less(self.out, 360.0)))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_fix_range_large_range(self):
-        """ Test fix_range success for input that deviates far from max/min
-        """
-        self.out = ocb_time.fix_range(self.vals, 0.0, 24.0)
-        self.assertTrue(np.all(np.greater_equal(self.out, 0.0)))
-        self.assertTrue(np.all(np.less(self.out, 24.0)))
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_fix_range_default_float(self):
-        """ Test fix_range success for a single value
-        """
-        self.out = ocb_time.fix_range(self.vals[0], 0.0, 360.0)
-        self.assertGreaterEqual(self.out, 0.0)
-        self.assertLess(self.out, 360.0)

--- a/ocbpy/tests/test_ocboundary.py
+++ b/ocbpy/tests/test_ocboundary.py
@@ -5,13 +5,11 @@
 # -----------------------------------------------------------------------------
 """ Tests the ocboundary class and functions
 """
-from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
 from io import StringIO
 import logging
 import numpy as np
-from sys import version_info
 from os import path
 import unittest
 
@@ -31,8 +29,6 @@ class TestOCBoundaryLogFailure(unittest.TestCase):
         """ Tear down the test case"""
         del self.lwarn, self.lout, self.log_capture
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_bad_instrument_name(self):
         """ Test OCB initialization with bad instrument name """
         self.lwarn = u"OCB instrument must be a string"
@@ -50,59 +46,6 @@ class TestOCBoundaryLogFailure(unittest.TestCase):
 
         del val, ocb
 
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_bad_instrument_int_name(self):
-        """ Test OCB initialization with a bad integer instrument name """
-        self.lwarn = u"OCB instrument must be a string"
-
-        # Initialize the OCBoundary class with bad instrument names
-        ocb = ocbpy.OCBoundary(instrument=1)
-        self.assertIsNone(ocb.filename)
-        self.assertIsNone(ocb.instrument)
-
-        self.lout = self.log_capture.getvalue()
-        # Test logging error message for each bad initialization
-        print(self.lout, self.lwarn)
-        self.assertTrue(self.lout.find(self.lwarn) >= 0)
-
-        del ocb
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_bad_instrument_none_name(self):
-        """ Test OCB initialization with a bad NoneType instrument name """
-        self.lwarn = u"OCB instrument must be a string"
-
-        # Initialize the OCBoundary class with bad instrument names
-        ocb = ocbpy.OCBoundary(instrument=None)
-        self.assertIsNone(ocb.filename)
-        self.assertIsNone(ocb.instrument)
-
-        self.lout = self.log_capture.getvalue()
-        # Test logging error message for each bad initialization
-        print(self.lout, self.lwarn)
-        self.assertTrue(self.lout.find(self.lwarn) >= 0)
-
-        del ocb
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_bad_instrument_boolean_name(self):
-        """ Test OCB initialization with a bad Boolean instrument name """
-        self.lwarn = u"OCB instrument must be a string"
-
-        # Initialize the OCBoundary class with bad instrument names
-        ocb = ocbpy.OCBoundary(instrument=True)
-        self.assertIsNone(ocb.filename)
-        self.assertIsNone(ocb.instrument)
-
-        self.lout = self.log_capture.getvalue()
-        # Test logging error message for each bad initialization
-        print(self.lout, self.lwarn)
-        self.assertTrue(self.lout.find(self.lwarn) >= 0)
-
-        del ocb
-
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_bad_file_name(self):
         """ Test OCB initialization with bad file name """
         self.lwarn = u"filename is not a string"
@@ -118,36 +61,6 @@ class TestOCBoundaryLogFailure(unittest.TestCase):
                 self.assertTrue(self.lout.find(self.lwarn) >= 0)
 
         del val, ocb
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_bad_file_name_int(self):
-        """ Test OCB initialization with a bad file name that's an integer"""
-        self.lwarn = u"filename is not a string"
-
-        # Initialize the OCBoundary class with bad instrument names
-        ocb = ocbpy.OCBoundary(filename=1)
-        self.assertIsNone(ocb.filename)
-
-        self.lout = self.log_capture.getvalue()
-        # Test logging error message for each bad initialization
-        self.assertTrue(self.lout.find(self.lwarn) >= 0)
-
-        del ocb
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_bad_filename_bool(self):
-        """ Test OCB initialization with a bad file name that's a Boolean"""
-        self.lwarn = u"filename is not a string"
-
-        # Initialize the OCBoundary class with bad instrument names
-        ocb = ocbpy.OCBoundary(filename=True)
-        self.assertIsNone(ocb.filename)
-
-        self.lout = self.log_capture.getvalue()
-        # Test logging error message for each bad initialization
-        self.assertTrue(self.lout.find(self.lwarn) >= 0)
-
-        del ocb
 
     def test_bad_filename(self):
         """ Test OCB initialization with a bad default file/instrument pairing
@@ -223,8 +136,6 @@ class TestOCBoundaryInstruments(unittest.TestCase):
     def tearDown(self):
         del self.test_dir, self.inst_attrs, self.inst_init, self.ocb
 
-    @unittest.skipIf(version_info.major == 2,
-                     'Python 2.7 does not support subTest')
     def test_instrument_loading(self):
         """ Test OCB initialization with good instrument names """
         for ocb_kwargs in self.inst_init:
@@ -238,58 +149,6 @@ class TestOCBoundaryInstruments(unittest.TestCase):
                     self.assertFalse(hasattr(self.ocb, tattr))
 
         del ocb_kwargs, tattr
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_image_loading(self):
-        """ Test OCB initialization for IMAGE names """
-        self.ocb = ocbpy.OCBoundary(**self.inst_init[0])
-
-        for tattr in self.inst_attrs['image']:
-            self.assertTrue(hasattr(self.ocb, tattr))
-
-        for tattr in self.not_attrs['image']:
-            self.assertFalse(hasattr(self.ocb, tattr))
-
-        del tattr
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_ampere_loading(self):
-        """ Test OCB initialization for AMPERE names """
-        self.ocb = ocbpy.OCBoundary(**self.inst_init[3])
-
-        for tattr in self.inst_attrs['ampere']:
-            self.assertTrue(hasattr(self.ocb, tattr))
-
-        for tattr in self.not_attrs['ampere']:
-            self.assertFalse(hasattr(self.ocb, tattr))
-
-        del tattr
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_dmsp_ssj_north_loading(self):
-        """ Test OCB initialization for DMSP-SSJ North names """
-        self.ocb = ocbpy.OCBoundary(**self.inst_init[1])
-
-        for tattr in self.inst_attrs['dmsp-ssj']:
-            self.assertTrue(hasattr(self.ocb, tattr))
-
-        for tattr in self.not_attrs['dmsp-ssj']:
-            self.assertFalse(hasattr(self.ocb, tattr))
-
-        del tattr
-
-    @unittest.skipIf(version_info.major == 3, 'Already tested, remove in 2020')
-    def test_dmsp_ssj_south_loading(self):
-        """ Test OCB initialization for DMSP-SSJ South names """
-        self.ocb = ocbpy.OCBoundary(**self.inst_init[2])
-
-        for tattr in self.inst_attrs['dmsp-ssj']:
-            self.assertTrue(hasattr(self.ocb, tattr))
-
-        for tattr in self.not_attrs['dmsp-ssj']:
-            self.assertFalse(hasattr(self.ocb, tattr))
-
-        del tattr
 
 
 class TestOCBoundaryMethodsGeneral(unittest.TestCase):
@@ -307,10 +166,6 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
         self.assertTrue(path.isfile(self.set_empty['filename']))
         self.assertTrue(path.isfile(self.set_default['filename']))
         self.ocb = None
-
-        if version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-            self.assertRegex = self.assertRegexpMatches
 
     def tearDown(self):
         del self.set_empty, self.set_default, self.ocb
@@ -342,23 +197,14 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
         """ Test the unset class representation """
 
         self.ocb = ocbpy.ocboundary.OCBoundary(filename=None)
-
-        if version_info.major == 2:
-            self.assertRegexpMatches(self.ocb.__repr__(),
-                                     "No Open-Closed Boundary file specified")
-        else:
-            self.assertRegex(self.ocb.__repr__(),
-                             "No Open-Closed Boundary file specified")
+        self.assertRegex(self.ocb.__repr__(),
+                         "No Open-Closed Boundary file specified")
 
     def test_empty_file_repr(self):
         """ Test the class representation with an empty data file"""
 
         self.ocb = ocbpy.ocboundary.OCBoundary(**self.set_empty)
-
-        if version_info.major == 2:
-            self.assertRegexpMatches(self.ocb.__repr__(), "No data loaded")
-        else:
-            self.assertRegex(self.ocb.__repr__(), "No data loaded")
+        self.assertRegex(self.ocb.__repr__(), "No data loaded")
 
     def test_nofile_init(self):
         """ Ensure that the class can be initialised without loading a file.
@@ -1268,10 +1114,7 @@ class TestOCBoundaryMatchData(unittest.TestCase):
 
 class TestOCBoundaryFailure(unittest.TestCase):
     def setUp(self):
-        """ Initialize the OCBoundary object using the test file
-        """
-        if version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+        pass
 
     def tearDown(self):
         pass

--- a/ocbpy/tests/test_pysat.py
+++ b/ocbpy/tests/test_pysat.py
@@ -5,13 +5,11 @@
 # -----------------------------------------------------------------------------
 """ Tests the ocb_scaling class and functions
 """
-from __future__ import absolute_import, unicode_literals
 
 from io import StringIO
 import logging
 import numpy as np
 from os import path
-from sys import version_info
 import unittest
 
 import ocbpy
@@ -43,11 +41,6 @@ class TestPysatUtils(unittest.TestCase):
         self.pysat_keys = list()
         self.arevectors = list(),
         self.nkeys = 0
-
-        # Remove in 2020 when dropping support for 2.7
-        if version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def tearDown(self):
         """Delete attributes"""
@@ -161,10 +154,8 @@ class TestPysatUtils(unittest.TestCase):
 @unittest.skipIf(not no_pysat, "pysat installed, cannot test failure")
 class TestPysatFailure(unittest.TestCase):
     def setUp(self):
-        """ Initialize, allowing use of python 2.7 """
-        # Remove in 2020 when dropping support for 2.7
-        if version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
+        """ No setup needed"""
+        pass
 
     def tearDown(self):
         """ No teardown needed"""
@@ -174,15 +165,14 @@ class TestPysatFailure(unittest.TestCase):
         """ Test pysat import failure"""
 
         with self.assertRaisesRegex(ImportError, 'unable to load the pysat'):
-            import ocbpy.instruments.pysat_instruments as ocb_pysat
+            import ocbpy.instruments.pysat_instruments as ocb_pysat  # NOQA 401
 
 
 @unittest.skipIf(no_pysat, "pysat not installed")
 class TestPysatStructure(unittest.TestCase):
     def setUp(self):
         """ No setup needed"""
-        if version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
+        pass
 
     def tearDown(self):
         """ No teardown needed"""
@@ -190,11 +180,7 @@ class TestPysatStructure(unittest.TestCase):
 
     def test_add_ocb_to_data_defaults(self):
         """ test the add_ocb_to_data function defaults"""
-
-        if version_info.major == 2:
-            defaults = ocb_pysat.add_ocb_to_data.func_defaults
-        else:
-            defaults = ocb_pysat.add_ocb_to_data.__defaults__
+        defaults = ocb_pysat.add_ocb_to_data.__defaults__
 
         for i in [0, 1, 8]:
             self.assertEqual(len(defaults[i]), 0)
@@ -212,11 +198,7 @@ class TestPysatStructure(unittest.TestCase):
 
     def test_add_ocb_to_metadata_defaults(self):
         """ test the add_ocb_to_metadata function defaults"""
-
-        if version_info.major == 2:
-            defaults = ocb_pysat.add_ocb_to_metadata.func_defaults
-        else:
-            defaults = ocb_pysat.add_ocb_to_metadata.__defaults__
+        defaults = ocb_pysat.add_ocb_to_metadata.__defaults__
 
         for i in [0, 2]:
             self.assertFalse(defaults[i])
@@ -257,11 +239,6 @@ class TestPysatMethods(unittest.TestCase):
 
         self.utils = TestPysatUtils("test_ocb_metadata")
         self.utils.setUp()
-
-        # Remove in 2020 when dropping support for 2.7
-        if version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def tearDown(self):
         self.utils.tearDown()
@@ -599,11 +576,6 @@ class TestPysatCustMethods(unittest.TestCase):
 
         self.utils = TestPysatUtils("test_ocb_metadata")
         self.utils.setUp()
-
-        # Remove in 2020 when dropping support for 2.7
-        if version_info.major == 2:
-            self.assertRegex = self.assertRegexpMatches
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def tearDown(self):
         self.utils.tearDown()

--- a/ocbpy/tests/test_supermag.py
+++ b/ocbpy/tests/test_supermag.py
@@ -8,7 +8,6 @@
 import datetime as dt
 import numpy as np
 import os
-from sys import version_info
 import platform
 import unittest
 
@@ -40,10 +39,6 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
         self.temp_output = os.path.join(self.ocb_dir, "tests", "test_data",
                                         "temp_smag")
 
-        # Remove this in 2020
-        if version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
     def tearDown(self):
         if os.path.isfile(self.temp_output):
             os.remove(self.temp_output)
@@ -51,8 +46,6 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
         del self.test_file, self.test_output_north, self.test_ocb
         del self.test_output_south, self.temp_output, self.test_eq_file
 
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
     def test_supermag2ascii_ocb_choose_north(self):
         """ Test the SuperMAG data processing for a mixed file choosing north
         """
@@ -83,8 +76,6 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
             self.assertTrue(filecmp.cmp(self.test_output_north,
                                         self.temp_output, shallow=False))
 
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
     def test_supermag2ascii_north_from_ocb(self):
         """ Test the SuperMAG data processing choosing north from OCBoundary
         """
@@ -119,8 +110,6 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
 
         del ocb
 
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
     def test_supermag2ascii_ocb_choose_south(self):
         """ Test the SuperMAG data processing for a mixed file choosing south
         """
@@ -151,8 +140,6 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
             self.assertTrue(filecmp.cmp(self.test_output_south,
                                         self.temp_output, shallow=False))
 
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
     def test_supermag2ascii_ocb_eq(self):
         """ Test hemisphere choice with southern and equatorial data
         """
@@ -183,8 +170,6 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
             self.assertTrue(filecmp.cmp(self.test_output_south,
                                         self.temp_output, shallow=False))
 
-    @unittest.skipIf(version_info.major < 3,
-                     'Already tested, remove in 2020')
     def test_supermag2ascii_hemi_options(self):
         """ Test SuperMAG conversion with different hemisphere options
         """
@@ -248,27 +233,6 @@ class TestSuperMAG2AsciiMethods(unittest.TestCase):
                                          instrument='image', hemisphere=1,
                                          ocbfile=self.test_ocb)
 
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_supermag2ascii_ocb_bad_output_str(self):
-        """ Test failure caused by an non-string output name
-        """
-        with self.assertRaisesRegex(IOError,
-                                    "output filename is not a string"):
-            ocb_ismag.supermag2ascii_ocb(self.test_file, 1,
-                                         ocbfile=self.test_ocb)
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_supermag2ascii_ocb_bad_input(self):
-        """ Test the failure when a bad SuperMAG file is input
-        """
-        with self.assertRaisesRegex(IOError, "SuperMAG file cannot be opened"):
-            ocb_ismag.supermag2ascii_ocb("fake_file", "fake_out",
-                                         ocbfile=self.test_ocb)
-
-    @unittest.skipIf(version_info.major < 3,
-                     'Already tested, remove in 2020')
     def test_supermag2ascii_ioerr_messages(self):
         """ Test the failures that produce reliable IOError messages
         """
@@ -306,10 +270,6 @@ class TestSuperMAGLoadMethods(unittest.TestCase):
         self.out = list()
         self.assertTrue(os.path.isfile(self.test_file))
 
-        # Remove this in 2020
-        if version_info.major == 2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
     def tearDown(self):
         del self.test_file, self.out, self.test_vals
 
@@ -328,29 +288,6 @@ class TestSuperMAGLoadMethods(unittest.TestCase):
         for kk in self.test_vals.keys():
             self.assertEqual(self.out[1][kk][-1], self.test_vals[kk])
 
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_load_failure(self):
-        """ Test the routine to load the SuperMAG data for bad filename """
-        self.out = ocb_ismag.load_supermag_ascii_data("fake_file")
-
-        # Test to see that the data keys are all in the header
-        self.assertListEqual(self.out[0], [])
-        self.assertListEqual(list(self.out[1].keys()), [])
-
-    @unittest.skipIf(version_info.major > 2,
-                     'Python 2.7 does not support subTest')
-    def test_wrong_load(self):
-        """ Test the routine to load the SuperMAG data """
-        bad_file = os.path.join(self.ocb_dir, "test", "test_data", "test_vort")
-        self.out = ocb_ismag.load_supermag_ascii_data(bad_file)
-
-        self.assertListEqual(self.out[0], list())
-        self.assertDictEqual(self.out[1], dict())
-        del bad_file
-
-    @unittest.skipIf(version_info.major < 3,
-                     'Already tested, remove in 2020')
     def test_load_failures(self):
         """ Test graceful failures with different bad file inputs"""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy<=1.15.4 ; python_version<='3.5'
-numpy>=1.19.0 ; python_version>='3.6'
+numpy
 aacgmv2
 coverage

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,15 @@
 # Full license can be found in License.md
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
 from os import path
 from setuptools import setup, find_packages
-from sys import version_info
 
 # Define a read function for using README for long_description
 def read(fname, fkwargs=dict()):
     return open(path.join(path.dirname(__file__), fname), **fkwargs).read()
 
-# Define default kwargs for python2/3
-read_kwargs = dict()
-if version_info.major == 3:
-    read_kwargs = {"encoding": "utf8"}
+# Define default kwargs for python 3
+read_kwargs = {"encoding": "utf8"}
 
 # Run setup
 setup(name='ocbpy',
@@ -34,11 +30,11 @@ setup(name='ocbpy',
           "Intended Audience :: Science/Research",
           "License :: OSI Approved :: BSD License",
           "Natural Language :: English",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3",
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.9",
           "Operating System :: MacOS :: MacOS X",
           "Operating System :: Microsoft :: Windows",
           "Operating System :: POSIX",


### PR DESCRIPTION
# Description

Removes support for Python 2.7.  Also cycles CI testing to include Python 3.9, improves some PEP8 style in the documentation, and fixes a bug in the header initialization that occurs when using the general instrument ASCII file loader.

Fixes #80 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality
  to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Running unit tests locally

**Test Configuration**:
- Operating system: OS X Mojave
- Version number: 3.7
- Any details about your local setup that are relevant: did not test pysat, since local system is set up for pysat 3.0.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst``