### PR TITLE
pysat 3.0.0 update

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -11,8 +11,10 @@ Summary of all changes made since the first stable release
 * ENH: Added a setup configuration file
 * MAINT: Removed support for Python 2.7 and 3.5
 * MAINT: Improved PEP8 compliance
+* MAINT: Updated pysat routines to v3.0.0 standards
 * TST: Integrated Requires.io
 * TST: Added flake8 tests to Travis CI
+* TST: Added pysat xarray tests to the pysat test suite
 
 
 0.2.1 (11-24-2020)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![DOI](https://zenodo.org/badge/96153180.svg)](https://zenodo.org/badge/latestdoi/96153180)
 [![PyPI version](https://badge.fury.io/py/ocbpy.svg)](https://badge.fury.io/py/ocbpy)
 
-[![Linux Status](https://www.travis-ci.org/aburrell/ocbpy.svg)](https://www.travis-ci.org/aburrell/ocbpy)
+[![Linux Status](https://www.travis-ci.com/aburrell/ocbpy.svg)](https://www.travis-ci.com/aburrell/ocbpy)
 [![Windows Status](https://ci.appveyor.com/api/projects/status/741n3cv8n68s280v?svg=true)](https://ci.appveyor.com/project/aburrell/ocbpy)
 [![Coverage Status](https://coveralls.io/repos/github/aburrell/ocbpy/badge.svg)](https://coveralls.io/github/aburrell/ocbpy)
 [![Requirements Status](https://requires.io/github/aburrell/ocbpy/requirements.svg?branch=main)](https://requires.io/github/aburrell/ocbpy/requirements/?branch=main)

--- a/ocbpy/instruments/pysat_instruments.py
+++ b/ocbpy/instruments/pysat_instruments.py
@@ -314,12 +314,11 @@ def add_ocb_to_data(pysat_inst, mlat_name='', mlt_name='', evar_names=list(),
         # The update procedure is different for pandas and xarray
         if pysat_inst.pandas_format:
             set_data = {oattr: ocb_output[oattr]}
+            pysat_inst.data = pysat_inst.data.assign(**set_data)
         else:
             # The OCB variable has the same dimensions as magnetic latitude
             set_data = {oattr: (pysat_inst[mlat_name].dims, ocb_output[oattr])}
-
-        # Add the OCB data to the pysat Instrument data object
-        pysat_inst.data = pysat_inst.data.assign(set_data)
+            pysat_inst.data = pysat_inst.data.assign(set_data)
 
         # Update the pysat Metadata
         eattr = oattr[:-4]

--- a/ocbpy/instruments/pysat_instruments.py
+++ b/ocbpy/instruments/pysat_instruments.py
@@ -227,7 +227,8 @@ def add_ocb_to_data(pysat_inst, mlat_name='', mlt_name='', evar_names=list(),
 
     # Ensure all data is from one hemisphere and is finite
     dat_ind = np.where((np.sign(aacgm_lat) == hemisphere)
-                       & (np.isfinite(pysat_inst[:, pysat_names].max())))[0]
+                       & (np.isfinite(pysat_inst[:,
+                                                 pysat_names].max(axis=1))))[0]
 
     # Test the OCB data
     if ocb.filename is None or ocb.records == 0:

--- a/ocbpy/instruments/pysat_instruments.py
+++ b/ocbpy/instruments/pysat_instruments.py
@@ -226,9 +226,12 @@ def add_ocb_to_data(pysat_inst, mlat_name='', mlt_name='', evar_names=list(),
         hemisphere = ocb.hemisphere
 
     # Ensure all data is from one hemisphere and is finite
-    dat_ind = np.where((np.sign(aacgm_lat) == hemisphere)
-                       & (np.isfinite(pysat_inst[:,
-                                                 pysat_names].max(axis=1))))[0]
+    if pysat_inst.pandas_format:
+        finite_mask = np.isfinite(pysat_inst[:, pysat_names].max(axis=1))
+    else:
+        finite_mask = np.isfinite(
+            pysat_inst[:, pysat_names].to_array().max('variable'))
+    dat_ind = np.where((np.sign(aacgm_lat) == hemisphere) & finite_mask)[0]
 
     # Test the OCB data
     if ocb.filename is None or ocb.records == 0:

--- a/ocbpy/tests/test_files.py
+++ b/ocbpy/tests/test_files.py
@@ -162,7 +162,7 @@ class TestFilesMethods(unittest.TestCase):
         """ Test the failure of the default boundary directory definition
         """
         ocbpy.__file__ = "/fake_dir/test_file"
-        with self.assertRaisesRegexp(OSError, "boundary file directory"):
+        with self.assertRaisesRegex(OSError, "boundary file directory"):
             files.get_boundary_directory()
 
     def test_get_boundary_files_unknown_boundary(self):

--- a/requirements.extra
+++ b/requirements.extra
@@ -7,9 +7,10 @@ EXTRAS=$1
 
 if [ $EXTRAS = 1 ]; then
     # Install pysat, which currently is not vetted for Windows.
-    # Although ocbpy works with pysat >= 2.0.0, the testing suite is not
-    # provided in versions below 2.2.1.
-    pip install -v pysat>=2.2.1
+    # Although older ocbpy work with pysat >= 2.0.0, the testing suite is not
+    # provided in versions below 2.2.1 and the custom function interface
+    # changed in pysat 3.0.0
+    pip install -v pysat>=3.0.0
     mkdir $HOME/pysatData
     echo "Installed pysat"
 elif [ $EXTRAS = 2 ]; then

--- a/requirements.extra
+++ b/requirements.extra
@@ -10,8 +10,9 @@ if [ $EXTRAS = 1 ]; then
     # Although older ocbpy work with pysat >= 2.0.0, the testing suite is not
     # provided in versions below 2.2.1 and the custom function interface
     # changed in pysat 3.0.0
-    pip install -v pysat>=3.0.0
+    pip install pysat>=3.0.0
     mkdir $HOME/pysatData
+    python -c "import pysat; pysat.params['data_dirs'] = '$HOME/pysatData'"
     echo "Installed pysat"
 elif [ $EXTRAS = 2 ]; then
     # Install code for ssj_auroral_boundary on linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,10 @@ author = Angeline G. Burrell, et al.
 author_email = angeline.burrell@nrl.navy.mil
 description = 'Location relative to open/closed field line boundary'
 keywords =
+  coordinates
+  field-line boundary
+  auroral oval
+  polar cap
   pysat
   ionosphere
   atmosphere
@@ -46,7 +50,7 @@ install_requires = aacgmv2
 		   numpy
 
 [options.extras_require]
-pysat_instruments = pysat>=2.0.0
+pysat_instruments = pysat>=3.0.0
 dmsp_ssj = ssj_auroral_boundaries
 
 [flake8]


### PR DESCRIPTION
# Description

Updates the `pysat_instrument` functions and unit tests to use pysat 3.0.0 syntax.  Also expands the unit tests to include both pandas and xarray based Instrument objects.  Partially addresses #93 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
  to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Running unit tests locally and adding more unit tests.

**Test Configuration**:
- Operating system: OS X Mojave
- Version number: 3.7
- Any details about your local setup that are relevant: using pysat 3.0.0 on the current main branch

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst``