### PR TITLE
Vorticity data bugs

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,6 +7,8 @@ Summary of all changes made since the first stable release
 ------------------
 * DEP: Removed deprecated functions that depend on ssj_auroral_boundary package
 * DEP: Removed deprecated methods, attributes, and kwargs in VectorData
+* DOC: Added data reference for SuperDARN vorticity data
+* BUG: Fixed `load_vorticity_ascii_data` to correctly cycle through files
 * BUG: Fixed `zenodo-get` import in pyproject.toml
 * TST: Updated GitHub Actions yamls
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -9,6 +9,7 @@ Summary of all changes made since the first stable release
 * DEP: Removed deprecated methods, attributes, and kwargs in VectorData
 * DOC: Added data reference for SuperDARN vorticity data
 * BUG: Fixed `load_vorticity_ascii_data` to correctly cycle through files
+* BUG: Fixed EAB index pairing issue in `DualBoundary` class
 * BUG: Fixed `zenodo-get` import in pyproject.toml
 * TST: Updated GitHub Actions yamls
 

--- a/ocbpy/_boundary.py
+++ b/ocbpy/_boundary.py
@@ -1281,7 +1281,8 @@ class DualBoundary(object):
                 max_tol=self.max_delta, **eab_kwargs)
 
             # Save the paired data
-            if iocb is not None and iocb < len(good_ocb):
+            if iocb is not None and iocb < len(
+                    good_ocb) and self.eab.rec_ind < self.eab.records:
                 self.dtime.append(self.ocb.dtime[good_ocb[iocb]])
                 self.ocb_ind.append(good_ocb[iocb])
                 self.eab_ind.append(self.eab.rec_ind)
@@ -1289,7 +1290,8 @@ class DualBoundary(object):
                 iocb = None
 
             # Cycle to the next good EAB index
-            self.eab.get_next_good_ocb_ind(**eab_kwargs)
+            if self.eab.rec_ind < self.eab.records:
+                self.eab.get_next_good_ocb_ind(**eab_kwargs)
 
         # Re-cast the class attributes as arrays
         self.dtime = np.asarray(self.dtime)

--- a/ocbpy/tests/test_boundary_dual.py
+++ b/ocbpy/tests/test_boundary_dual.py
@@ -265,6 +265,17 @@ class TestDualBoundaryMethodsGeneral(test_ocb.TestOCBoundaryMethodsGeneral):
                 self.assertEqual(self.ocb.eab.rec_ind, self.ocb.eab_ind[i])
         return
 
+    def test_assign_rec_ind_max_default(self):
+        """Test to see that `rec_ind` is only good values."""
+
+        # Initialize the object
+        self.ocb = self.test_class(**self.set_default)
+
+        # Ensure the sub-class indices are also above the allowed range
+        self.assertLess(self.ocb.ocb_ind[-1], self.ocb.ocb.records)
+        self.assertLess(self.ocb.eab_ind[-1], self.ocb.eab.records)
+        return
+
     def test_assign_rec_ind_max(self):
         """Test to see that setting `rec_ind` above the max is consistent."""
 
@@ -319,9 +330,18 @@ class TestDualBoundaryMethodsGeneral(test_ocb.TestOCBoundaryMethodsGeneral):
                 if method.find('eq') >= 0:
                     self.assertEqual(self.ocb.ocb.rec_ind, ocb_ind)
                     self.assertEqual(self.ocb.eab.rec_ind, eab_ind)
+                elif method == 'max':
+                    self.assertListEqual(list(self.ocb.eab_ind), [])
+                    self.assertListEqual(list(self.ocb.ocb_ind), [])
                 else:
-                    self.assertGreater(self.ocb.eab.rec_ind, eab_ind)
-                    self.assertGreater(self.ocb.ocb.rec_ind, ocb_ind)
+                    self.assertGreater(
+                        self.ocb.eab.rec_ind, eab_ind,
+                        msg="Unexpected EAB record from list: {:} {:}".format(
+                            self.ocb.eab.phi_cent, self.ocb.ocb_ind))
+                    self.assertGreater(
+                        self.ocb.ocb.rec_ind, ocb_ind,
+                        msg="Unexpected OCB record from list: {:}".format(
+                            self.ocb.ocb_ind))
         return
 
 

--- a/ocbpy/tests/test_vort.py
+++ b/ocbpy/tests/test_vort.py
@@ -57,33 +57,6 @@ class TestVortLogWarnings(cc.TestLogWarnings):
         self.eval_logging_message()
         return
 
-    def test_vort_unexpected_line(self):
-        """Testing vorticity catch for file loading."""
-
-        # Initalize the vorticity run with different test files
-        for val in [(u'unexpected line encountered when number of entries', 1),
-                    (u'unexpected line encountered for a data block', -1)]:
-            with self.subTest(val=val):
-                # Initalize the warning
-                self.lwarn = val[0]
-
-                # Create the bad file
-                with open(self.temp_output, 'w') as fout:
-                    with open(self.test_file, 'r') as fin:
-                        data = fin.readlines()
-                    data.pop(val[1])
-                    fout.write(''.join(data))
-
-                # Load the bad file
-                data = ocb_ivort.load_vorticity_ascii_data(self.temp_output)
-
-                # Test logging error message
-                self.eval_logging_message()
-
-                # Test the data output
-                self.assertIsNone(data)
-        return
-
 
 class TestVort2AsciiMethods(unittest.TestCase):
     """Test the vorticity instrument ASCII functions."""
@@ -118,6 +91,26 @@ class TestVort2AsciiMethods(unittest.TestCase):
         del self.test_file, self.temp_output, self.test_ocb, self.test_eq_file
         del self.test_output_north, self.test_output_south, self.test_eab
         del self.test_empty, self.test_output_dual, self.test_unscaled_north
+        return
+
+    def test_vort_unexpected_line(self):
+        """Testing vorticity catch for file loading."""
+
+        # Initalize the vorticity run with different test files
+        for val in [(u'unexpected line encountered when number of entries', 1),
+                    (u'unexpected line encountered for a data block', -1)]:
+            with self.subTest(val=val):
+                # Create the bad file
+                with open(self.temp_output, 'w') as fout:
+                    with open(self.test_file, 'r') as fin:
+                        data = fin.readlines()
+                    data.pop(val[1])
+                    fout.write(''.join(data))
+
+                # Load the bad file
+                with self.assertRaisesRegex(IOError, val[0]):
+                    ocb_ivort.load_vorticity_ascii_data(self.temp_output)
+
         return
 
     def test_vort2ascii_ocb(self):


### PR DESCRIPTION
# Description

Fixes #143 and #142.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

```
import datetime as dt
import numpy as np
import ocbpy
stime = dt.datetime(2000,1,1)
etime = dt.datetime(2005,1,1)
dual = ocbpy.DualBoundary(stime=stime, etime=etime, hemisphere=1)
np.all(dual.eab_ind < dual.eab.records)  # Should be True; if bug exists, this will be False
```

## Test Configuration

- Operating system: OS X Ventura
- Version number: Python 3.10
- Any details about your local setup that are relevant: N/A

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
