### PR TITLE
Update pysat cap

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         install-extras: ["base", "pysat_instruments", "dmsp_ssj"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with ${{ matrix.install-extras }}

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -12,6 +12,7 @@ Summary of all changes made since the first stable release
 * BUG: Fixed EAB index pairing issue in `DualBoundary` class
 * BUG: Fixed `zenodo-get` import in pyproject.toml
 * TST: Updated GitHub Actions yamls
+* MAINT: Cycled Python and pysat version support
 
 0.4.0 (06-07-2024)
 ------------------

--- a/README.md
+++ b/README.md
@@ -45,20 +45,18 @@ These routines may be used as a guide to write routines for other datasets.
 
 # Python versions
 
-This module currently supports Python version 3.9 - 3.12.
+This module currently supports Python version 3.10 - 3.13.
 
 # Dependencies
 
 The listed dependecies were tested with the following versions:
   * numpy
   * aacgmv2
-  * pysat (3.0.1+)
-  * ssj_auroral_boundary (deprecated)
+  * pysat (3.2.1+)
   * zenodo_get
 
 Testing is performed using the python module, unittest.  To limit dependency
-issues, the pysat, ssj_auroral_boundary, and zenodo_get dependencies are
-optional.
+issues, the pysat and zenodo_get dependencies are optional.
 
 # Installation
 

--- a/ocbpy/boundaries/dmsp_ssj_files.py
+++ b/ocbpy/boundaries/dmsp_ssj_files.py
@@ -72,7 +72,7 @@ def fetch_ssj_boundary_files(stime=None, etime=None, out_dir=None,
     Raises
     ------
     ValueError
-        If an unknown satellite ID is provided.
+        If an unknown satellite ID, DOI, or output directory is provided.
     IOError
         If unable to donwload the target archive and identify the zip file
     ImportError

--- a/ocbpy/tests/test_pysat.py
+++ b/ocbpy/tests/test_pysat.py
@@ -10,7 +10,6 @@
 
 import numpy as np
 from os import path
-from packaging import version
 import unittest
 
 import ocbpy
@@ -267,16 +266,7 @@ class PysatBase(TestPysatUtils):
 
         self.test_inst = pysat.Instrument(inst_module=self.test_module,
                                           **self.pysat_kw)
-
-        # Reduce pysat warnings
-        # TODO(#130) remove version checking by updating minimum supported pysat
-        load_kwargs = {'date': self.ocb.dtime[self.rec_ind]}
-        if version.Version(pysat.__version__) > version.Version(
-                '3.0.1') and version.Version(
-                    pysat.__version__) < version.Version('3.2.0'):
-            load_kwargs['use_header'] = True
-
-        self.test_inst.load(**load_kwargs)
+        self.test_inst.load(date=self.ocb.dtime[self.rec_ind])
         return
 
     def set_new_keys(self, exclude_r_corr=True):
@@ -815,11 +805,7 @@ class TestPysatMethodsXarray(TestPysatMethods):
         super().setUp()
 
         # Update the method defaults
-        # TODO(#130) remove version checking by updating minimum supported pysat
-        if version.Version(pysat.__version__) < version.Version('3.1.0'):
-            self.test_module = pysat.instruments.pysat_testing2d_xarray
-        else:
-            self.test_module = pysat.instruments.pysat_ndtesting
+        self.test_module = pysat.instruments.pysat_ndtesting
 
         return
 
@@ -1201,11 +1187,7 @@ class TestPysatCustMethodsXarray(TestPysatCustMethods):
         super().setUp()
 
         # Update the class defaults
-        # TODO(#130) remove version checking by updating minimum supported pysat
-        if version.Version(pysat.__version__) < version.Version('3.1.0'):
-            self.test_module = pysat.instruments.pysat_testing2d_xarray
-        else:
-            self.test_module = pysat.instruments.pysat_ndtesting
+        self.test_module = pysat.instruments.pysat_ndtesting
         return
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = 'Location relative to open/closed field line boundary'
 maintainers = [
     {name = "Angeline G. Burrell", email = "angeline.g.burrell.civ@us.navy.mil"},
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "aacgmv2",
     "numpy",
@@ -42,10 +42,10 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     'Operating System :: Unix',
     'Operating System :: POSIX',
     'Operating System :: POSIX :: Linux',
@@ -54,12 +54,12 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-pysat_instruments = [ "pysat>=3.0.1" ]
+pysat_instruments = [ "pysat>=3.2.1" ]
 dmsp_ssj = [ "zenodo-get" ]
 doc = [
     "numpydoc",
     "pyproject_parser",
-    "pysat>=3.0.1",
+    "pysat>=3.2.1",
     "sphinx>=1.3",
     "sphinx-rtd-theme",
 ]


### PR DESCRIPTION
# Description

Fixes #130 by updated the supported pysat and Python versions.

## Type of change

Please delete options that are not relevant.

- This change requires a documentation update

# How Has This Been Tested?

Ran unit tests with most recent version of pysat.

## Test Configuration

- Operating system: OS X Ventura
- Version number: Python 3.10
- Any details about your local setup that are relevant: pysat 3.2.1

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
