### PR TITLE
Convert boundary class to dict

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -6,6 +6,7 @@ Summary of all changes made since the first stable release
 0.6.0 (XX-XX-2025)
 ------------------
 * ENH: Updated the AMPERE boundaries to include 2022-2024, inclusive
+* ENH: Added `to_dict` method to the boundary class objects
 
 0.5.0 (01-28-2025)
 ------------------

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -14,3 +14,4 @@ convert between AACGM and OCB coordinates, and more.
    examples/ex_general.rst
    examples/ex_vector.rst
    examples/ex_pysat_eab.rst
+   examples/ex_save_boundaries.rst

--- a/docs/examples/ex_save_boundaries.rst
+++ b/docs/examples/ex_save_boundaries.rst
@@ -1,0 +1,56 @@
+.. _exsave:
+
+Export and Save Boundaries
+==========================
+
+You may wish to save the boundary data contained in the various Boundary classes
+to a file or use it in another data format. All the Boundary classes have a
+:py:func:`to_dict` method that exports the data into two dictionaries, one
+that contains the boundary information and one that contains the class metadata.
+The dictionary may be formatted to simply hold the data using similarly-named
+keys or may be formatted to allow the creation of an :py:class:`xarray.Dataset`.
+
+::
+
+   ocb_data, ocb_info = ocb.to_dict()
+   print(ocb_info.keys(), '\n', ocb_data.keys())
+
+
+This will show the following keys.  Note that all of the information keys are
+single-value quantities that are useful for reproducibility, and the data keys
+directly correspond to the class attributes in
+:py:class:`~ocbpy._boundary.OCBoundary` or
+:py:class:`~ocbpy._boundary.EABoundary` that are obtained directly or
+calculated from the instrument boundary files.
+
+::
+   
+   dict_keys(['instrument', 'filename', 'hemisphere', 'min_fom', 'max_fom', 'boundary_lat']) 
+   dict_keys(['dtime', 'phi_cent', 'r_cent', 'r', 'fom', 'year', 'soy', 'num_sectors', 'a', 'r_err'])
+
+The :py:class:`~ocbpy._boundary.DualBoundary` output is slightly different, as
+it will contain the OCB and EAB pairs.
+
+::
+
+   dual_data, dual_info = dual.to_dict()
+   print(dual_info.keys(), '\n', dual_data.keys())
+
+
+Note that attributes pulled from each boundary have the boundary prepended to
+the key.
+
+::
+
+   dict_keys(['eab_instrument', 'eab_filename', 'eab_min_fom', 'eab_max_fom', 'eab_boundary_lat', 'ocb_instrument', 'ocb_filename', 'ocb_min_fom', 'ocb_max_fom', 'ocb_boundary_lat', 'hemisphere', 'max_delta']) 
+   dict_keys(['dtime', 'eab_phi_cent', 'eab_r_cent', 'eab_r', 'eab_fom', 'eab_year', 'eab_soy', 'eab_num_sectors', 'eab_a', 'eab_r_err', 'ocb_phi_cent', 'ocb_r_cent', 'ocb_r', 'ocb_fom', 'ocb_year', 'ocb_soy', 'ocb_num_sectors', 'ocb_a', 'ocb_r_err'])
+
+You can create a netCDF file with this data using :py:mod:`xarray`.
+
+::
+
+   import xarray as xr
+
+   dual_data, dual_info = dual.to_dict(xarray_style=True)
+   dual_dataset = xr.Dataset(dual_data, attr=dual_info)
+   dual_dataset.to_netcdf('/path/to/dual_boundary.nc')

--- a/docs/examples/ex_save_boundaries.rst
+++ b/docs/examples/ex_save_boundaries.rst
@@ -52,5 +52,5 @@ You can create a netCDF file with this data using :py:mod:`xarray`.
    import xarray as xr
 
    dual_data, dual_info = dual.to_dict(xarray_style=True)
-   dual_dataset = xr.Dataset(dual_data, attr=dual_info)
+   dual_dataset = xr.Dataset(dual_data, attrs=dual_info)
    dual_dataset.to_netcdf('/path/to/dual_boundary.nc')

--- a/ocbpy/_boundary.py
+++ b/ocbpy/_boundary.py
@@ -113,6 +113,8 @@ class OCBoundary(object):
         Convert the position of a measurement in OCB into AACGM co-ordinates.
     get_aacgm_boundary_lat
         Calculate the OCB latitude in AACGM coordinates at specified MLTs.
+    to_dict
+        Provide the data in this class as a pair of dictionaries.
 
     Raises
     ------
@@ -869,6 +871,75 @@ class OCBoundary(object):
 
         return
 
+    def to_dict(self, xarray_style=False):
+        """Convert the boundary data into a pair of dictionaries.
+
+        Parameters
+        ----------
+        xarray_style : bool
+            If True, dict values will be a tuple with a tuple of dimensions as
+            first item and data as the second item (default=False)
+
+        Returns
+        -------
+        data : dict
+            Output with class data attributes as keys
+        info : dict
+            Output with class informational attributes as keys
+
+        Raises
+        ------
+        ValueError
+            If output type is inconsistent with class data
+
+        """
+        # Initialize the output
+        data = dict()
+        info = dict()
+
+        # Set the class informational attributes and attributes to exclude
+        bnd_info = ['instrument', 'filename', 'min_fom', 'max_fom',
+                    'hemisphere', 'boundary_lat']
+        exc_attr = ['records', 'rec_ind', 'rfunc', 'rfunc_kwargs']
+
+        # Determine whether or not 2D attributes are present and in the correct
+        # format (xarray only)
+        if xarray_style and hasattr(self, 'aacgm_boundary_mlt'):
+            uniq_mlt = np.unique(self.aacgm_boundary_mlt)
+
+            if not np.all(uniq_mlt == self.aacgm_boundary_mlt[0]):
+                raise ValueError(''.join(['Boundary MLT must be uniquely ',
+                                          'defined for xarray output']))
+
+        # Cycle through all class attributes
+        for attr in self.__dict__.keys():
+            if attr in bnd_info:
+                # This is an informative attribute
+                info[attr] = getattr(self, attr)
+            elif attr not in exc_attr and not callable(getattr(self, attr)):
+                # This is a data attribute
+                if xarray_style:
+                    # If output to convert from a dict to xarray Dataset is
+                    # desired, we need to specify the dimensions and the data
+                    if attr.find('aacgm_boundary_') == 0:
+                        if attr == 'aacgm_boundary_mlt':
+                            val = (('aacgm_boundary_mlt'), uniq_mlt)
+                        else:
+                            val = (('dtime', 'aacgm_boundary_mlt'),
+                                   np.array(getattr(self, attr)))
+                    else:
+                        val = (('dtime'), getattr(self, attr))
+                else:
+                    # If we just want the data as a dict, no conversions are
+                    # needed
+                    val = getattr(self, attr)
+
+                # Assign the correctly styled value to the data dict
+                data[attr] = val
+
+        # Return the desired dicts
+        return data, info
+
 
 class EABoundary(OCBoundary):
     """Object containing equatorward auroral boundary (EAB) data.
@@ -1073,6 +1144,8 @@ class DualBoundary(object):
         Calculate the EAB and OCB latitude in AACGM coordinates.
     calc_r
         Calculate the scaled and unscaled radius at a normalised co-ordinates.
+    to_dict
+        Provide the data in this class as a pair of dictionaries.
 
     Raises
     ------

--- a/ocbpy/_boundary.py
+++ b/ocbpy/_boundary.py
@@ -1983,9 +1983,9 @@ class DualBoundary(object):
                             if xarray_style:
                                 comp_dat = data[dkey][1] == sub_data[dkey][1]
                             else:
-                                comp_dat = [np.all(data[dkey][i] == sdat)
-                                            for i, sdat in enumerate(
-                                                    sub_data[dkey])]
+                                comp_dat = [
+                                    np.all(data[dkey][i] == sdat)
+                                    for i, sdat in enumerate(sub_data[dkey])]
 
                             if not np.all(comp_dat):
                                 raise ValueError(''.join([

--- a/ocbpy/_boundary.py
+++ b/ocbpy/_boundary.py
@@ -872,7 +872,7 @@ class OCBoundary(object):
 
         return
 
-    def to_dict(self, xarray_style=False):
+    def to_dict(self, xarray_style=False, sel_inds=None):
         """Convert the boundary data into a pair of dictionaries.
 
         Parameters
@@ -880,6 +880,9 @@ class OCBoundary(object):
         xarray_style : bool
             If True, dict values will be a tuple with a tuple of dimensions as
             first item and data as the second item (default=False)
+        sel_inds : list or NoneType
+            Output a subset of the data to the dictionaries if not None
+            (default=None)
 
         Returns
         -------
@@ -898,6 +901,9 @@ class OCBoundary(object):
         data = dict()
         info = dict()
 
+        if sel_inds is None:
+            sel_inds = np.arange(0, self.records, 1)
+
         # Set the class informational attributes and attributes to exclude
         bnd_info = ['instrument', 'filename', 'min_fom', 'max_fom',
                     'hemisphere', 'boundary_lat']
@@ -906,9 +912,15 @@ class OCBoundary(object):
         # Determine whether or not 2D attributes are present and in the correct
         # format (xarray only)
         if xarray_style and hasattr(self, 'aacgm_boundary_mlt'):
-            uniq_mlt = np.unique(self.aacgm_boundary_mlt)
+            sel_mlt = [self.aacgm_boundary_mlt[i] for i in sel_inds]
+            try:
+                uniq_mlt = np.unique(sel_mlt)
+            except (ValueError, TypeError):
+                raise ValueError(''.join(['Boundary MLT must be uniquely ',
+                                          'defined for xarray output']))
 
-            if not np.all(uniq_mlt == self.aacgm_boundary_mlt[0]):
+            # Catch MLT differences with the right shape and wrong values
+            if not np.all(uniq_mlt == sel_mlt[0]):
                 raise ValueError(''.join(['Boundary MLT must be uniquely ',
                                           'defined for xarray output']))
 
@@ -927,13 +939,18 @@ class OCBoundary(object):
                             val = (('aacgm_boundary_mlt'), uniq_mlt)
                         else:
                             val = (('dtime', 'aacgm_boundary_mlt'),
-                                   np.array(getattr(self, attr)))
+                                   np.array([getattr(self, attr)[i]
+                                             for i in sel_inds]))
                     else:
-                        val = (('dtime'), getattr(self, attr))
+                        val = (('dtime'), getattr(self, attr)[sel_inds])
                 else:
                     # If we just want the data as a dict, no conversions are
                     # needed
-                    val = getattr(self, attr)
+                    try:
+                        val = getattr(self, attr)[sel_inds]
+                    except (ValueError, TypeError):
+                        # Necessary if a sub-set of boundary coords are defined
+                        val = [getattr(self, attr)[sind] for sind in sel_inds]
 
                 # Assign the correctly styled value to the data dict
                 data[attr] = val
@@ -1900,3 +1917,92 @@ class DualBoundary(object):
             return scaled_r[0], unscaled_r[0]
         else:
             return scaled_r, unscaled_r
+
+    def to_dict(self, xarray_style=False, sel_inds=None):
+        """Convert the boundary data into a pair of dictionaries.
+
+        Parameters
+        ----------
+        xarray_style : bool
+            If True, dict values will be a tuple with a tuple of dimensions as
+            first item and data as the second item (default=False)
+        sel_inds : list or NoneType
+            Output a subset of the paired data to the dictionaries if not None
+            (default=None)
+
+        Returns
+        -------
+        data : dict
+            Output with class data attributes as keys
+        info : dict
+            Output with class informational attributes as keys
+
+        Raises
+        ------
+        ValueError
+            If output type is inconsistent with class data
+
+        """
+        # Initialize the output
+        data = dict()
+        info = dict()
+
+        if sel_inds is None:
+            sel_inds = np.arange(0, self.records, 1)
+
+        # Set the class informational and sub-class attributes
+        bnd_info = ['hemisphere', 'max_delta']
+        sub_class = ['ocb', 'eab']
+
+        # Cycle through all class attributes
+        for attr in self.__dict__.keys():
+            if attr in bnd_info:
+                # This is an informative attribute
+                info[attr] = getattr(self, attr)
+            elif attr in sub_class:
+                # Get the dicts from the sub-class for the paired, selected data
+                if len(sel_inds) == 0:
+                    sub_inds = None
+                else:
+                    sub_inds = getattr(self, "_".join([attr, "ind"]))[sel_inds]
+                sub_data, sub_info = getattr(self, attr).to_dict(
+                    xarray_style=xarray_style, sel_inds=sub_inds)
+
+                # Assign the sub-class information to the info dict
+                for ikey in sub_info:
+                    if ikey not in bnd_info:
+                        skey = "_".join([attr, ikey])
+                        info[skey] = sub_info[ikey]
+
+                # Assign the paired, selected values to the data dict
+                for dkey in sub_data:
+                    if dkey == 'aacgm_boundary_mlt':
+                        if dkey not in data.keys():
+                            data[dkey] = sub_data[dkey]
+                        else:
+                            if xarray_style:
+                                comp_dat = data[dkey][1] == sub_data[dkey][1]
+                            else:
+                                comp_dat = [np.all(data[dkey][i] == sdat)
+                                            for i, sdat in enumerate(
+                                                    sub_data[dkey])]
+
+                            if not np.all(comp_dat):
+                                raise ValueError(''.join([
+                                    'Boundary MLT must be uniquely defined ',
+                                    ' for xarray output']))
+                    elif dkey == 'dtime':
+                        # Get the time from the DualBoundary class
+                        if dkey not in data.keys():
+                            if xarray_style:
+                                data[dkey] = ((dkey),
+                                              getattr(self, dkey)[sel_inds])
+                            else:
+                                data[dkey] = getattr(self, dkey)[sel_inds]
+                    else:
+                        # Reform the name and assign the paired, selected data
+                        skey = "_".join([attr, dkey])
+                        data[skey] = sub_data[dkey]
+
+        # Return the desired dicts
+        return data, info

--- a/ocbpy/_boundary.py
+++ b/ocbpy/_boundary.py
@@ -197,10 +197,11 @@ class OCBoundary(object):
     def __repr__(self):
         """Provide an evaluatable representation of the OCBoundary object."""
         class_name = repr(self.__class__).split("'")[1]
+        isempty = True if self.dtime is None or len(self.dtime) == 0 else False
 
         # Get the start and end times
-        stime = None if self.dtime is None else self.dtime[0]
-        etime = None if self.dtime is None else self.dtime[-1]
+        stime = None if isempty else self.dtime[0]
+        etime = None if isempty else self.dtime[-1]
 
         # Format the function representations
         if self.rfunc is None:

--- a/ocbpy/tests/test_boundary_dual.py
+++ b/ocbpy/tests/test_boundary_dual.py
@@ -130,6 +130,40 @@ class TestDualBoundaryMethodsGeneral(test_ocb.TestOCBoundaryMethodsGeneral):
                             "max_delta": 600}
         return
 
+    def eval_dict(self, isxarray=False, sel_ind=None):
+        """Evaluate the dictionary output.
+
+        Parameters
+        ----------
+        isxarray : bool
+            True if xarray-compatible output is expected (default=False)
+        sel_ind : list or NoneType
+            Subset of data to output, or None for all (default=None)
+
+        """
+        # Evaluate the informational data
+        self.assertEqual(len(self.info.keys()), 12)
+
+        for ikey in self.info.keys():
+            if ikey.find('eab') < 0 and ikey.find('ocb') < 0:
+                self.assertEqual(self.info[ikey], getattr(self.ocb, ikey))
+
+        # Evaluate the data values
+        self.assertGreaterEqual(len(self.data.keys()), 9)
+
+        for dkey in self.data.keys():
+            if isxarray:
+                self.assertIsInstance(self.data[dkey], tuple)
+                self.assertTrue(len(self.data[dkey][0]),
+                                len(self.data[dkey][1].shape))
+            elif sel_ind is None:
+                self.assertEqual(self.ocb.records, len(self.data[dkey]))
+            else:
+                # Test that the output is the expected length
+                self.assertEqual(len(sel_ind), len(self.data[dkey]))
+
+        return
+
     def test_repr_string(self):
         """Test __repr__ method string."""
         # Initalize the class object
@@ -342,6 +376,52 @@ class TestDualBoundaryMethodsGeneral(test_ocb.TestOCBoundaryMethodsGeneral):
                         self.ocb.ocb.rec_ind, ocb_ind,
                         msg="Unexpected OCB record from list: {:}".format(
                             self.ocb.ocb_ind))
+        return
+
+    def test_to_dict_with_uniform_aacgm_boundaries(self):
+        """Test that class data can be converted to dicts with extra data."""
+        self.ocb = self.test_class(**self.set_default)
+        self.ocb.get_aacgm_boundary_lats([0.5, 12.0])
+
+        # Cycle through both output styles
+        for isxarray in [True, False]:
+            with self.subTest(xarray_style=isxarray):
+                # Test with extra parameters
+                self.data, self.info = self.ocb.to_dict(xarray_style=isxarray)
+                self.eval_dict(isxarray=isxarray)
+        return
+
+    def test_to_dict_with_varied_aacgm_boundaries(self):
+        """Test that class data with some extra can be converted to dicts."""
+        self.ocb = self.test_class(**self.set_default)
+        self.ocb.get_aacgm_boundary_lats([0.5, 12.0], rec_ind=0)
+
+        # Test with extra, varied parameters
+        self.data, self.info = self.ocb.to_dict(xarray_style=False)
+        self.eval_dict(isxarray=False)
+        return
+
+    def test_to_dict_with_varied_aacgm_boundaries_xarray(self):
+        """Test failure to create xarray-style dict with some extra data."""
+        self.ocb = self.test_class(**self.set_default)
+        self.ocb.ocb.get_aacgm_boundary_lat([0.5, 12.0])
+        self.ocb.eab.get_aacgm_boundary_lat([1.5, 22.0])
+
+        with self.assertRaisesRegex(ValueError,
+                                    "Boundary MLT must be uniquely defined"):
+            self.ocb.to_dict(xarray_style=True)
+        return
+
+    def test_to_dict_with_varied_sel_aacgm_boundaries_xarray(self):
+        """Test creation of xarray-style dict with some extra, selected data."""
+        self.ocb = self.test_class(**self.set_default)
+        sel_inds = [0, 2]
+        self.ocb.get_aacgm_boundary_lats([0.5, 12.0], rec_ind=sel_inds)
+
+        # Run for xarray, but only selecting the good, extra data
+        self.data, self.info = self.ocb.to_dict(xarray_style=True,
+                                                sel_inds=sel_inds)
+        self.eval_dict(isxarray=True, sel_ind=sel_inds)
         return
 
 

--- a/ocbpy/tests/test_boundary_ocb.py
+++ b/ocbpy/tests/test_boundary_ocb.py
@@ -207,13 +207,15 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
         del self.data, self.info
         return
 
-    def eval_dict(self, isxarray=False):
+    def eval_dict(self, isxarray=False, sel_ind=None):
         """Evaluate the dictionary output.
 
         Parameters
         ----------
         isxarray : bool
             True if xarray-compatible output is expected (default=False)
+        sel_ind : list or NoneType
+            Subset of data to output, or None for all (default=None)
 
         """
         # Evaluate the informational data
@@ -230,9 +232,17 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
                 self.assertIsInstance(self.data[dkey], tuple)
                 self.assertTrue(len(self.data[dkey][0]),
                                 len(self.data[dkey][1].shape))
-            else:
+            elif sel_ind is None:
                 self.assertTrue(numpy.all(self.data[dkey]
                                           == getattr(self.ocb, dkey)))
+            else:
+                # Test that the output is the expected length
+                self.assertEqual(len(sel_ind), len(self.data[dkey]))
+
+                # Test the correct values were selected
+                for i, ind in enumerate(sel_ind):
+                    self.assertEqual(self.data[dkey][i],
+                                     getattr(self.ocb, dkey)[ind])
         return
 
     def test_repr_string(self):
@@ -382,13 +392,16 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
 
         # Cycle through both output styles
         for isxarray in [True, False]:
-            with self.subTest(xarray_style=isxarray):
-                # Test with base parameters
-                self.data, self.info = self.ocb.to_dict(xarray_style=isxarray)
-                self.eval_dict(isxarray=isxarray)
+            # Cycle through data subsets
+            for sel_ind in [None, [0, 2, 4]]:
+                with self.subTest(xarray_style=isxarray, sel_ind=sel_ind):
+                    # Test with base parameters
+                    self.data, self.info = self.ocb.to_dict(
+                        xarray_style=isxarray, sel_inds=sel_ind)
+                    self.eval_dict(isxarray=isxarray, sel_ind=sel_ind)
         return
 
-    def test_to_dict_with_aacgm_boundaries(self):
+    def test_to_dict_with_uniform_aacgm_boundaries(self):
         """Test that class data can be converted to dicts with extra data."""
         self.ocb = self.test_class(**self.set_default)
         self.ocb.get_aacgm_boundary_lat([0.5, 12.0])
@@ -396,9 +409,41 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
         # Cycle through both output styles
         for isxarray in [True, False]:
             with self.subTest(xarray_style=isxarray):
-                # Test with base parameters
+                # Test with extra parameters
                 self.data, self.info = self.ocb.to_dict(xarray_style=isxarray)
                 self.eval_dict(isxarray=isxarray)
+        return
+
+    def test_to_dict_with_varied_aacgm_boundaries(self):
+        """Test that class data with some extra can be converted to dicts."""
+        self.ocb = self.test_class(**self.set_default)
+        self.ocb.get_aacgm_boundary_lat([0.5, 12.0], rec_ind=[0])
+
+        # Test with extra, varied parameters
+        self.data, self.info = self.ocb.to_dict(xarray_style=False)
+        self.eval_dict(isxarray=False)
+        return
+
+    def test_to_dict_with_varied_aacgm_boundaries_xarray(self):
+        """Test failure to create xarray-style dict with some extra data."""
+        self.ocb = self.test_class(**self.set_default)
+        self.ocb.get_aacgm_boundary_lat([0.5, 12.0], rec_ind=[0])
+
+        with self.assertRaisesRegex(ValueError,
+                                    "Boundary MLT must be uniquely defined"):
+            self.ocb.to_dict(xarray_style=True)
+        return
+
+    def test_to_dict_with_varied_sel_aacgm_boundaries_xarray(self):
+        """Test creation of xarray-style dict with some extra, selected data."""
+        self.ocb = self.test_class(**self.set_default)
+        sel_inds = [0, 2]
+        self.ocb.get_aacgm_boundary_lat([0.5, 12.0], rec_ind=sel_inds)
+
+        # Run for xarray, but only selecting the good, extra data
+        self.data, self.info = self.ocb.to_dict(xarray_style=True,
+                                                sel_inds=sel_inds)
+        self.eval_dict(isxarray=True, sel_ind=sel_inds)
         return
 
     def test_to_dict_empty(self):
@@ -408,7 +453,7 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
         # Cycle through both output styles
         for isxarray in [True, False]:
             with self.subTest(xarray_style=isxarray):
-                # Test with base parameters
+                # Test with empty parameters
                 self.data, self.info = self.ocb.to_dict(xarray_style=isxarray)
                 self.eval_dict(isxarray=isxarray)
         return

--- a/ocbpy/tests/test_boundary_ocb.py
+++ b/ocbpy/tests/test_boundary_ocb.py
@@ -197,11 +197,42 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
                                                   "test_north_ocb"),
                             "instrument": "image"}
         self.ocb = None
+        self.data = None
+        self.info = None
         return
 
     def tearDown(self):
         """Clean up the test environment."""
         del self.set_empty, self.set_default, self.ocb, self.test_class
+        del self.data, self.info
+        return
+
+    def eval_dict(self, isxarray=False):
+        """Evaluate the dictionary output.
+
+        Parameters
+        ----------
+        isxarray : bool
+            True if xarray-compatible output is expected (default=False)
+
+        """
+        # Evaluate the informational data
+        self.assertEqual(len(self.info.keys()), 6)
+
+        for ikey in self.info.keys():
+            self.assertEqual(self.info[ikey], getattr(self.ocb, ikey))
+
+        # Evaluate the data values
+        self.assertGreaterEqual(len(self.data.keys()), 5)
+
+        for dkey in self.data.keys():
+            if isxarray:
+                self.assertIsInstance(self.data[dkey], tuple)
+                self.assertTrue(len(self.data[dkey][0]),
+                                len(self.data[dkey][1].shape))
+            else:
+                self.assertTrue(numpy.all(self.data[dkey]
+                                          == getattr(self.ocb, dkey)))
         return
 
     def test_repr_string(self):
@@ -239,6 +270,13 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
     def test_repr_eval(self):
         """Test __repr__ method's ability to reproduce a class."""
         self.ocb = self.test_class(**self.set_default)
+        test_ocb = eval(repr(self.ocb))
+        self.assertEqual(repr(self.ocb), repr(test_ocb))
+        return
+
+    def test_repr_empty(self):
+        """Test __repr__ method's ability to reproduce an empty object."""
+        self.ocb = self.test_class(**self.set_empty)
         test_ocb = eval(repr(self.ocb))
         self.assertEqual(repr(self.ocb), repr(test_ocb))
         return
@@ -336,6 +374,43 @@ class TestOCBoundaryMethodsGeneral(unittest.TestCase):
                     self.assertEqual(self.ocb.rec_ind, comp_ind)
                 else:
                     self.assertGreater(self.ocb.rec_ind, comp_ind)
+        return
+
+    def test_to_dict(self):
+        """Test that class data can be converted to dicts."""
+        self.ocb = self.test_class(**self.set_default)
+
+        # Cycle through both output styles
+        for isxarray in [True, False]:
+            with self.subTest(xarray_style=isxarray):
+                # Test with base parameters
+                self.data, self.info = self.ocb.to_dict(xarray_style=isxarray)
+                self.eval_dict(isxarray=isxarray)
+        return
+
+    def test_to_dict_with_aacgm_boundaries(self):
+        """Test that class data can be converted to dicts with extra data."""
+        self.ocb = self.test_class(**self.set_default)
+        self.ocb.get_aacgm_boundary_lat([0.5, 12.0])
+
+        # Cycle through both output styles
+        for isxarray in [True, False]:
+            with self.subTest(xarray_style=isxarray):
+                # Test with base parameters
+                self.data, self.info = self.ocb.to_dict(xarray_style=isxarray)
+                self.eval_dict(isxarray=isxarray)
+        return
+
+    def test_to_dict_empty(self):
+        """Test that empty class data can be converted to dicts."""
+        self.ocb = self.test_class(**self.set_empty)
+
+        # Cycle through both output styles
+        for isxarray in [True, False]:
+            with self.subTest(xarray_style=isxarray):
+                # Test with base parameters
+                self.data, self.info = self.ocb.to_dict(xarray_style=isxarray)
+                self.eval_dict(isxarray=isxarray)
         return
 
 


### PR DESCRIPTION
# Description

Added a method to convert data held in the different boundary classes to a dict.  The style of the dict may be simple or facilitate loading an xarray dataset.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Wrote new unit tests and added an example.  Used to save data to netCDF.

## Test Configuration

- Operating system: OS X Ventura
- Version number: Python 3.10
- Any details about your local setup that are relevant: pysat develop
- 
# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
