### PR TITLE
Zenodo bugfix

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,6 +7,7 @@ Summary of all changes made since the first stable release
 ------------------
 * ENH: Updated the AMPERE boundaries to include 2022-2024, inclusive
 * ENH: Added `to_dict` method to the boundary class objects
+* BUG: Supported newest version of zenodo_get, which underwent breaking changes
 
 0.5.0 (01-28-2025)
 ------------------

--- a/ocbpy/boundaries/dmsp_ssj_files.py
+++ b/ocbpy/boundaries/dmsp_ssj_files.py
@@ -114,7 +114,11 @@ def fetch_ssj_boundary_files(stime=None, etime=None, out_dir=None,
     sys.stderr = zenodo_io
 
     zenodo_checksum = os.path.join(out_dir, 'md5sums.txt')
-    zenodo_get.zenodo_get([doi, '-o', out_dir])
+    # TODO(#151): remove the old (second) way of calling zenodo_get 
+    if hasattr(zenodo_get, "download"):
+        zenodo_get.download(doi=doi, output_dir=out_dir, md5=True)
+    else:
+        zenodo_get.zenodo_get([doi, '-o', out_dir])
 
     # Parse the output and retrieve files from the zip archive
     sys.stdout = sys.__stdout__


### PR DESCRIPTION
# Description

Fixes a bug introduced by breaking changes to zenodo_get (see https://github.com/dvolgyes/zenodo_get/issues/3#issuecomment-2905857034), which now allows for a pythonic function call for downloading files.  Currently supporting old and new versions.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran unit tests after installing newest version of zenodo_get.

## Test Configuration

- Operating system: OS X Big Sur
- Version number: Python 3.10
- Any details about your local setup that are relevant: zenodo_get 2.0.0

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
